### PR TITLE
add patch manifest support

### DIFF
--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -200,7 +200,7 @@ func ListServerGroupManagers(c *gin.Context) {
 		replicaSets := &unstructured.UnstructuredList{}
 
 		lo := metav1.ListOptions{
-			LabelSelector: kubernetes.LabelKubernetesSpinnakerApp + "=" + application,
+			LabelSelector: kubernetes.LabelKubernetesName + "=" + application,
 		}
 
 		deploymentGVR := schema.GroupVersionResource{
@@ -214,13 +214,13 @@ func ListServerGroupManagers(c *gin.Context) {
 			Resource: "replicasets",
 		}
 
-		deployments, err = client.List(deploymentGVR, lo)
+		deployments, err = client.ListByGVR(deploymentGVR, lo)
 		if err != nil {
 			log.Println("error listing deployments:", err.Error())
 			continue
 		}
 
-		replicaSets, err = client.List(replicaSetGVR, lo)
+		replicaSets, err = client.ListByGVR(replicaSetGVR, lo)
 		if err != nil {
 			log.Println("error listing replicaSets:", err.Error())
 			continue
@@ -389,7 +389,7 @@ func ListLoadBalancers(c *gin.Context) {
 		// Label selector for all that we are listing in the cluster. We
 		// only want to list resources that have a label referencing the requested application.
 		lo := metav1.ListOptions{
-			LabelSelector: kubernetes.LabelKubernetesSpinnakerApp + "=" + application,
+			LabelSelector: kubernetes.LabelKubernetesName + "=" + application,
 		}
 
 		// TODO get these using the dynamic account.
@@ -400,7 +400,7 @@ func ListLoadBalancers(c *gin.Context) {
 			Resource: "ingresses",
 		}
 
-		ingresses, err := client.List(ingressGVR, lo)
+		ingresses, err := client.ListByGVR(ingressGVR, lo)
 		if err != nil {
 			log.Println("error listing ingresses:", err.Error())
 			continue
@@ -417,7 +417,7 @@ func ListLoadBalancers(c *gin.Context) {
 			Resource: "services",
 		}
 
-		services, err := client.List(serviceGVR, lo)
+		services, err := client.ListByGVR(serviceGVR, lo)
 		if err != nil {
 			log.Println("error listing services:", err.Error())
 			continue
@@ -636,7 +636,7 @@ func ListServerGroups(c *gin.Context) {
 		}
 
 		lo := metav1.ListOptions{
-			LabelSelector: kubernetes.LabelKubernetesSpinnakerApp + "=" + application,
+			LabelSelector: kubernetes.LabelKubernetesName + "=" + application,
 		}
 
 		// Create a GVR for replicasets.
@@ -650,13 +650,13 @@ func ListServerGroups(c *gin.Context) {
 			Resource: "pods",
 		}
 
-		replicaSets, err := client.List(replicaSetGVR, lo)
+		replicaSets, err := client.ListByGVR(replicaSetGVR, lo)
 		if err != nil {
 			log.Println("error listing replicaSets:", err.Error())
 			continue
 		}
 
-		pods, err := client.List(podsGVR, lo)
+		pods, err := client.ListByGVR(podsGVR, lo)
 		if err != nil {
 			log.Println("error listing pods:", err.Error())
 			continue
@@ -820,7 +820,7 @@ func GetServerGroup(c *gin.Context) {
 	}
 
 	lo := metav1.ListOptions{
-		LabelSelector: kubernetes.LabelKubernetesSpinnakerApp + "=" + application,
+		LabelSelector: kubernetes.LabelKubernetesName + "=" + application,
 	}
 
 	podsGVR := schema.GroupVersionResource{
@@ -835,7 +835,7 @@ func GetServerGroup(c *gin.Context) {
 	}
 
 	// "Instances" in kubernetes are pods.
-	pods, err := client.List(podsGVR, lo)
+	pods, err := client.ListByGVR(podsGVR, lo)
 	if err != nil {
 		clouddriver.WriteError(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/applications_test.go
+++ b/pkg/http/core/applications_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Application", func() {
 				"account1",
 				"account2",
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(0, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(0, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -119,7 +119,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(1, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(1, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -138,7 +138,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(2, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(2, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -157,7 +157,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(3, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(3, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -245,8 +245,8 @@ var _ = Describe("Application", func() {
 
 		When("listing deployments returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListReturnsOnCall(0, nil, errors.New("error listing deployments"))
-				fakeKubeClient.ListReturnsOnCall(1, nil, errors.New("error listing deployments"))
+				fakeKubeClient.ListByGVRReturnsOnCall(0, nil, errors.New("error listing deployments"))
+				fakeKubeClient.ListByGVRReturnsOnCall(1, nil, errors.New("error listing deployments"))
 			})
 
 			It("continues", func() {
@@ -256,8 +256,8 @@ var _ = Describe("Application", func() {
 
 		When("listing replicasets returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListReturnsOnCall(1, nil, errors.New("error listing replicaSets"))
-				fakeKubeClient.ListReturnsOnCall(3, nil, errors.New("error listing replicaSets"))
+				fakeKubeClient.ListByGVRReturnsOnCall(1, nil, errors.New("error listing replicaSets"))
+				fakeKubeClient.ListByGVRReturnsOnCall(3, nil, errors.New("error listing replicaSets"))
 			})
 
 			It("continues", func() {
@@ -282,7 +282,7 @@ var _ = Describe("Application", func() {
 				"account1",
 				"account2",
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(0, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(0, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -301,7 +301,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(1, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(1, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -315,7 +315,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(2, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(2, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -334,7 +334,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(3, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(3, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -417,8 +417,8 @@ var _ = Describe("Application", func() {
 
 		When("listing ingresses returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListReturnsOnCall(0, nil, errors.New("error listing ingresses"))
-				fakeKubeClient.ListReturnsOnCall(1, nil, errors.New("error listing ingresses"))
+				fakeKubeClient.ListByGVRReturnsOnCall(0, nil, errors.New("error listing ingresses"))
+				fakeKubeClient.ListByGVRReturnsOnCall(1, nil, errors.New("error listing ingresses"))
 			})
 
 			It("continues", func() {
@@ -428,8 +428,8 @@ var _ = Describe("Application", func() {
 
 		When("listing services returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListReturnsOnCall(1, nil, errors.New("error listing services"))
-				fakeKubeClient.ListReturnsOnCall(3, nil, errors.New("error listing services"))
+				fakeKubeClient.ListByGVRReturnsOnCall(1, nil, errors.New("error listing services"))
+				fakeKubeClient.ListByGVRReturnsOnCall(3, nil, errors.New("error listing services"))
 			})
 
 			It("continues", func() {
@@ -530,7 +530,7 @@ var _ = Describe("Application", func() {
 				"account1",
 				"account2",
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(0, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(0, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -572,7 +572,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(1, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(1, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -596,7 +596,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(2, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(2, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -638,7 +638,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListReturnsOnCall(3, &unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturnsOnCall(3, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -731,8 +731,8 @@ var _ = Describe("Application", func() {
 
 		When("listing replicasets returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListReturnsOnCall(0, nil, errors.New("error listing replicasets"))
-				fakeKubeClient.ListReturnsOnCall(1, nil, errors.New("error listing replicasets"))
+				fakeKubeClient.ListByGVRReturnsOnCall(0, nil, errors.New("error listing replicasets"))
+				fakeKubeClient.ListByGVRReturnsOnCall(1, nil, errors.New("error listing replicasets"))
 			})
 
 			It("continues", func() {
@@ -742,8 +742,8 @@ var _ = Describe("Application", func() {
 
 		When("listing pods returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListReturnsOnCall(1, nil, errors.New("error listing pods"))
-				fakeKubeClient.ListReturnsOnCall(3, nil, errors.New("error listing pods"))
+				fakeKubeClient.ListByGVRReturnsOnCall(1, nil, errors.New("error listing pods"))
+				fakeKubeClient.ListByGVRReturnsOnCall(3, nil, errors.New("error listing pods"))
 			})
 
 			It("continues", func() {
@@ -764,7 +764,7 @@ var _ = Describe("Application", func() {
 			setup()
 			uri = svr.URL + "/applications/test-application/serverGroups/test-account/test-namespace/replicaSet test-rs1"
 			createRequest(http.MethodGet)
-			fakeKubeClient.ListReturns(&unstructured.UnstructuredList{
+			fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -931,7 +931,7 @@ var _ = Describe("Application", func() {
 
 		When("listing pods returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListReturns(nil, errors.New("error listing pods"))
+				fakeKubeClient.ListByGVRReturns(nil, errors.New("error listing pods"))
 			})
 
 			It("returns an error", func() {

--- a/pkg/http/core/core_test.go
+++ b/pkg/http/core/core_test.go
@@ -55,6 +55,28 @@ func setup() {
 
 	fakeKubeClient = &kubernetesfakes.FakeClient{}
 	fakeKubeClient.GetReturns(&unstructured.Unstructured{Object: map[string]interface{}{}}, nil)
+	fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+						},
+					},
+				},
+			},
+			{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+						},
+					},
+				},
+			},
+		},
+	}, nil)
 
 	fakeKubeController = &kubernetesfakes.FakeController{}
 	fakeKubeController.NewClientReturns(fakeKubeClient, nil)

--- a/pkg/http/core/credentials.go
+++ b/pkg/http/core/credentials.go
@@ -169,7 +169,7 @@ func ListCredentials(c *gin.Context) {
 					Resource: "namespaces",
 				}
 				// timeout listing namespaces to 5 seconds
-				result, err := client.List(gvr, metav1.ListOptions{
+				result, err := client.ListByGVR(gvr, metav1.ListOptions{
 					TimeoutSeconds: &listNamespacesTimeout,
 				})
 				if err != nil {

--- a/pkg/http/core/credentials_test.go
+++ b/pkg/http/core/credentials_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Credential", func() {
 						},
 					},
 				}, nil)
-				fakeKubeClient.ListReturns(&unstructured.UnstructuredList{
+				fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
 							Object: map[string]interface{}{
@@ -254,7 +254,7 @@ var _ = Describe("Credential", func() {
 
 			When("listing namespaces returns an error", func() {
 				BeforeEach(func() {
-					fakeKubeClient.ListReturns(nil, errors.New("error listing"))
+					fakeKubeClient.ListByGVRReturns(nil, errors.New("error listing"))
 				})
 
 				It("continues", func() {

--- a/pkg/http/core/kubernetes/action.go
+++ b/pkg/http/core/kubernetes/action.go
@@ -27,6 +27,7 @@ type ActionHandler interface {
 	NewRollingRestartAction(ActionConfig) Action
 	NewRollbackAction(ActionConfig) Action
 	NewScaleManifestAction(ActionConfig) Action
+	NewPatchManifestAction(ActionConfig) Action
 }
 
 const ActionHandlerInstanceKey = `KubernetesActionHandler`

--- a/pkg/http/core/kubernetes/kubernetes_test.go
+++ b/pkg/http/core/kubernetes/kubernetes_test.go
@@ -53,7 +53,7 @@ func setup() {
 	}
 	fakeKubeClient = &kubernetesfakes.FakeClient{}
 	fakeKubeClient.GetReturns(&unstructured.Unstructured{Object: map[string]interface{}{}}, nil)
-	fakeKubeClient.ListReturns(ul, nil)
+	fakeKubeClient.ListByGVRReturns(ul, nil)
 
 	fakeKubeController = &kubernetesfakes.FakeController{}
 	fakeKubeController.NewClientReturns(fakeKubeClient, nil)
@@ -144,6 +144,26 @@ func newActionConfig() ActionConfig {
 				Location:      "",
 				User:          "",
 				Account:       "",
+			},
+			PatchManifest: &PatchManifestRequest{
+				App:          "",
+				Cluster:      "",
+				Criteria:     "",
+				Kind:         "",
+				ManifestName: "deployment test-deployment",
+				Source:       "",
+				Mode:         "",
+				PatchBody: map[string]interface{}{
+					"": nil,
+				},
+				CloudProvider: "",
+				AllArtifacts:  nil,
+				Options: PatchManifestRequestOptions{
+					MergeStrategy: "",
+					Record:        false,
+				},
+				Location: "",
+				Account:  "",
 			},
 		},
 	}

--- a/pkg/http/core/kubernetes/kubernetes_test.go
+++ b/pkg/http/core/kubernetes/kubernetes_test.go
@@ -71,99 +71,30 @@ func newActionConfig() ActionConfig {
 		Application:    "test-application",
 		Operation: Operation{
 			DeployManifest: &DeployManifestRequest{
-				EnableTraffic:     false,
-				NamespaceOverride: "",
-				OptionalArtifacts: nil,
-				CloudProvider:     "",
 				Manifests: []map[string]interface{}{
 					{
 						"kind":       "Pod",
 						"apiVersion": "v1",
 					},
 				},
-				TrafficManagement: struct {
-					Options struct {
-						EnableTraffic bool "json:\"enableTraffic\""
-					} "json:\"options\""
-					Enabled bool "json:\"enabled\""
-				}{
-					Options: struct {
-						EnableTraffic bool "json:\"enableTraffic\""
-					}{
-						EnableTraffic: false,
-					},
-					Enabled: false,
-				},
-				Moniker: struct {
-					App string "json:\"app\""
-				}{
-					App: "",
-				},
-				Source:                   "",
-				Account:                  "",
-				SkipExpressionEvaluation: false,
-				RequiredArtifacts:        nil,
 			},
 			ScaleManifest: &ScaleManifestRequest{
-				Replicas:      "16",
-				ManifestName:  "deployment test-deployment",
-				CloudProvider: "",
-				Location:      "",
-				User:          "",
-				Account:       "",
+				Replicas:     "16",
+				ManifestName: "deployment test-deployment",
 			},
-			CleanupArtifacts: &CleanupArtifactsRequest{
-				Manifests: nil,
-				Account:   "",
-			},
+			CleanupArtifacts: &CleanupArtifactsRequest{},
 			DeleteManifest: &DeleteManifestRequest{
-				ManifestName:  "deployment test-deployment",
-				CloudProvider: "",
-				Options: struct {
-					OrphanDependants   bool "json:\"orphanDependants\""
-					GracePeriodSeconds int  "json:\"gracePeriodSeconds\""
-				}{
-					OrphanDependants:   false,
-					GracePeriodSeconds: 0,
-				},
-				Location: "",
-				User:     "",
-				Account:  "",
+				ManifestName: "deployment test-deployment",
 			},
 			UndoRolloutManifest: &UndoRolloutManifestRequest{
-				ManifestName:  "deployment test-deployment",
-				CloudProvider: "",
-				Location:      "",
-				User:          "",
-				Account:       "",
-				Revision:      "100",
+				ManifestName: "deployment test-deployment",
+				Revision:     "100",
 			},
 			RollingRestartManifest: &RollingRestartManifestRequest{
-				CloudProvider: "",
-				ManifestName:  "deployment test-deployment",
-				Location:      "",
-				User:          "",
-				Account:       "",
+				ManifestName: "deployment test-deployment",
 			},
 			PatchManifest: &PatchManifestRequest{
-				App:          "",
-				Cluster:      "",
-				Criteria:     "",
-				Kind:         "",
 				ManifestName: "deployment test-deployment",
-				Source:       "",
-				Mode:         "",
-				PatchBody: map[string]interface{}{
-					"": nil,
-				},
-				CloudProvider: "",
-				AllArtifacts:  nil,
-				Options: PatchManifestRequestOptions{
-					MergeStrategy: "",
-					Record:        false,
-				},
-				Location: "",
-				Account:  "",
 			},
 		},
 	}

--- a/pkg/http/core/kubernetes/kubernetesfakes/fake_action_handler.go
+++ b/pkg/http/core/kubernetes/kubernetesfakes/fake_action_handler.go
@@ -52,6 +52,17 @@ type FakeActionHandler struct {
 	newScaleManifestActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
+	NewPatchManifestActionStub        func(kubernetes.ActionConfig) kubernetes.Action
+	newPatchManifestActionMutex       sync.RWMutex
+	newPatchManifestActionArgsForCall []struct {
+		arg1 kubernetes.ActionConfig
+	}
+	newPatchManifestActionReturns struct {
+		result1 kubernetes.Action
+	}
+	newPatchManifestActionReturnsOnCall map[int]struct {
+		result1 kubernetes.Action
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -248,6 +259,54 @@ func (fake *FakeActionHandler) NewScaleManifestActionReturnsOnCall(i int, result
 	}{result1}
 }
 
+func (fake *FakeActionHandler) NewPatchManifestAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
+	fake.newPatchManifestActionMutex.Lock()
+	ret, specificReturn := fake.newPatchManifestActionReturnsOnCall[len(fake.newPatchManifestActionArgsForCall)]
+	fake.newPatchManifestActionArgsForCall = append(fake.newPatchManifestActionArgsForCall, struct {
+		arg1 kubernetes.ActionConfig
+	}{arg1})
+	fake.recordInvocation("NewPatchManifestAction", []interface{}{arg1})
+	fake.newPatchManifestActionMutex.Unlock()
+	if fake.NewPatchManifestActionStub != nil {
+		return fake.NewPatchManifestActionStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.newPatchManifestActionReturns.result1
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionCallCount() int {
+	fake.newPatchManifestActionMutex.RLock()
+	defer fake.newPatchManifestActionMutex.RUnlock()
+	return len(fake.newPatchManifestActionArgsForCall)
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionArgsForCall(i int) kubernetes.ActionConfig {
+	fake.newPatchManifestActionMutex.RLock()
+	defer fake.newPatchManifestActionMutex.RUnlock()
+	return fake.newPatchManifestActionArgsForCall[i].arg1
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionReturns(result1 kubernetes.Action) {
+	fake.NewPatchManifestActionStub = nil
+	fake.newPatchManifestActionReturns = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.NewPatchManifestActionStub = nil
+	if fake.newPatchManifestActionReturnsOnCall == nil {
+		fake.newPatchManifestActionReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Action
+		})
+	}
+	fake.newPatchManifestActionReturnsOnCall[i] = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
 func (fake *FakeActionHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -259,6 +318,8 @@ func (fake *FakeActionHandler) Invocations() map[string][][]interface{} {
 	defer fake.newRollbackActionMutex.RUnlock()
 	fake.newScaleManifestActionMutex.RLock()
 	defer fake.newScaleManifestActionMutex.RUnlock()
+	fake.newPatchManifestActionMutex.RLock()
+	defer fake.newPatchManifestActionMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/http/core/kubernetes/ops.go
+++ b/pkg/http/core/kubernetes/ops.go
@@ -16,6 +16,7 @@ type Operation struct {
 	DeleteManifest         *DeleteManifestRequest         `json:"deleteManifest"`
 	UndoRolloutManifest    *UndoRolloutManifestRequest    `json:"undoRolloutManifest"`
 	RollingRestartManifest *RollingRestartManifestRequest `json:"rollingRestartManifest"`
+	PatchManifest          *PatchManifestRequest          `json:"patchManifest"`
 }
 
 type DeployManifestRequest struct {
@@ -37,6 +38,42 @@ type DeployManifestRequest struct {
 	Account                  string        `json:"account"`
 	SkipExpressionEvaluation bool          `json:"skipExpressionEvaluation"`
 	RequiredArtifacts        []interface{} `json:"requiredArtifacts"`
+}
+
+type PatchManifestRequest struct {
+	App           string                         `json:"app"`
+	Cluster       string                         `json:"cluster"`
+	Criteria      string                         `json:"criteria"`
+	Kind          string                         `json:"kind"`
+	ManifestName  string                         `json:"manifestName"`
+	Source        string                         `json:"source"`
+	Mode          string                         `json:"mode"`
+	PatchBody     map[string]interface{}         `json:"patchBody"`
+	CloudProvider string                         `json:"cloudProvider"`
+	AllArtifacts  []PatchManifestRequestArtifact `json:"allArtifacts"`
+	Options       PatchManifestRequestOptions    `json:"options"`
+	// Manifests         []map[string]interface{}       `json:"manifests"`
+	Location string `json:"location"`
+	Account  string `json:"account"`
+	// RequiredArtifacts []interface{}                  `json:"requiredArtifacts"`
+}
+
+type PatchManifestRequestArtifact struct {
+	CustomKind bool   `json:"customKind"`
+	Reference  string `json:"reference"`
+	Metadata   struct {
+		Account string `json:"account"`
+	} `json:"metadata"`
+	Name     string `json:"name"`
+	Location string `json:"location"`
+	Type     string `json:"type"`
+	Version  string `json:"version"`
+}
+
+// Merge strategy can be "strategic", "json", or "merge".
+type PatchManifestRequestOptions struct {
+	MergeStrategy string `json:"mergeStrategy"`
+	Record        bool   `json:"record"`
 }
 
 type ManifestResponse struct {

--- a/pkg/http/core/kubernetes/patch.go
+++ b/pkg/http/core/kubernetes/patch.go
@@ -1,0 +1,116 @@
+package kubernetes
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	"github.com/billiford/go-clouddriver/pkg/arcade"
+	"github.com/billiford/go-clouddriver/pkg/kubernetes"
+	"github.com/billiford/go-clouddriver/pkg/sql"
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+)
+
+func (ah *actionHandler) NewPatchManifestAction(ac ActionConfig) Action {
+	return &patchManfest{
+		ac: ac.ArcadeClient,
+		sc: ac.SQLClient,
+		kc: ac.KubeController,
+		id: ac.ID,
+		pm: ac.Operation.PatchManifest,
+	}
+}
+
+type patchManfest struct {
+	ac arcade.Client
+	sc sql.Client
+	kc kubernetes.Controller
+	id string
+	pm *PatchManifestRequest
+}
+
+func (p *patchManfest) Run() error {
+	provider, err := p.sc.GetKubernetesProvider(p.pm.Account)
+	if err != nil {
+		return err
+	}
+
+	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
+	if err != nil {
+		return err
+	}
+
+	token, err := p.ac.Token()
+	if err != nil {
+		return err
+	}
+
+	config := &rest.Config{
+		Host:        provider.Host,
+		BearerToken: token,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: cd,
+		},
+	}
+
+	client, err := p.kc.NewClient(config)
+	if err != nil {
+		return err
+	}
+
+	// TODO how will this work with other merge types?
+	b, err := json.Marshal(p.pm.PatchBody)
+	if err != nil {
+		return err
+	}
+
+	// Manifest name is *really* the Spinnaker cluster - i.e. "deployment test-deployment", so we
+	// need to split on a whitespace and get the actual name of the manifest.
+	name := p.pm.ManifestName
+
+	a := strings.Split(p.pm.ManifestName, " ")
+	if len(a) > 1 {
+		name = a[1]
+	}
+
+	// Merge strategy can be "strategic", "json", or "merge".
+	strategy := types.StrategicMergePatchType
+
+	switch p.pm.Options.MergeStrategy {
+	case "json":
+		strategy = types.JSONPatchType
+	case "merge":
+		strategy = types.MergePatchType
+	}
+
+	meta, _, err := client.PatchUsingStrategy(p.pm.Kind, name, p.pm.Location, b, strategy)
+	if err != nil {
+		return err
+	}
+
+	// TODO Record the applied patch in the kubernetes.io/change-cause annotation. If the annotation already exists, the contents are replaced.
+	if p.pm.Options.Record {
+	}
+
+	kr := kubernetes.Resource{
+		AccountName:  p.pm.Account,
+		ID:           uuid.New().String(),
+		TaskID:       p.id,
+		APIGroup:     meta.Group,
+		Name:         meta.Name,
+		Namespace:    meta.Namespace,
+		Resource:     meta.Resource,
+		Version:      meta.Version,
+		Kind:         meta.Kind,
+		SpinnakerApp: p.pm.App,
+	}
+
+	err = p.sc.CreateKubernetesResource(kr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/http/core/kubernetes/patch_test.go
+++ b/pkg/http/core/kubernetes/patch_test.go
@@ -1,0 +1,112 @@
+package kubernetes_test
+
+import (
+	"errors"
+
+	"github.com/billiford/go-clouddriver/pkg/kubernetes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Patch", func() {
+	BeforeEach(func() {
+		setup()
+	})
+
+	JustBeforeEach(func() {
+		action = actionHandler.NewPatchManifestAction(actionConfig)
+		err = action.Run()
+	})
+
+	When("getting the provider returns an error", func() {
+		BeforeEach(func() {
+			fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+		})
+
+		It("returns an error", func() {
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("error getting provider"))
+		})
+	})
+
+	When("there is an error decoding the CA data for the kubernetes provider", func() {
+		BeforeEach(func() {
+			fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{CAData: "{}{}{}{}"}, nil)
+		})
+
+		It("returns an error", func() {
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("illegal base64 data at input byte 0"))
+		})
+	})
+
+	When("getting the gcloud access token returns an error", func() {
+		BeforeEach(func() {
+			fakeArcadeClient.TokenReturns("", errors.New("error getting token"))
+		})
+
+		It("returns an error", func() {
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("error getting token"))
+		})
+	})
+
+	When("creating the kube client returns an error", func() {
+		BeforeEach(func() {
+			fakeKubeController.NewClientReturns(nil, errors.New("bad config"))
+		})
+
+		It("returns an error", func() {
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("bad config"))
+		})
+	})
+
+	When("patching the manifest returns an error", func() {
+		BeforeEach(func() {
+			fakeKubeClient.PatchUsingStrategyReturns(kubernetes.Metadata{}, nil, errors.New("error patching manifest"))
+		})
+
+		It("returns an error", func() {
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("error patching manifest"))
+		})
+	})
+
+	When("creating the resource returns an error", func() {
+		BeforeEach(func() {
+			fakeSQLClient.CreateKubernetesResourceReturns(errors.New("error creating resource"))
+		})
+
+		It("returns an error", func() {
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal("error creating resource"))
+		})
+	})
+
+	Context("when it succeeds", func() {
+		Context("json patch type", func() {
+			BeforeEach(func() {
+				actionConfig.Operation.PatchManifest.Options.MergeStrategy = "json"
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("merge patch type", func() {
+			BeforeEach(func() {
+				actionConfig.Operation.PatchManifest.Options.MergeStrategy = "merge"
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		It("succeeds", func() {
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/pkg/http/core/kubernetes/rollback.go
+++ b/pkg/http/core/kubernetes/rollback.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
 
@@ -100,17 +99,16 @@ func (r *rollback) Run() error {
 		return err
 	}
 
-	replicaSetGVR := schema.GroupVersionResource{
-		Group:    "apps",
-		Version:  "v1",
-		Resource: "replicasets",
-	}
-	// TODO we might need to set this to just be 'spinnaker-managed'.
-	lo := metav1.ListOptions{
-		LabelSelector: kubernetes.LabelKubernetesSpinnakerApp + "=" + r.application,
+	replicaSetGVR, err := client.GVRForKind("ReplicaSet")
+	if err != nil {
+		return err
 	}
 
-	replicaSets, err := client.List(replicaSetGVR, lo)
+	lo := metav1.ListOptions{
+		LabelSelector: kubernetes.LabelKubernetesName + "=" + r.application,
+	}
+
+	replicaSets, err := client.ListByGVR(replicaSetGVR, lo)
 	if err != nil {
 		return err
 	}

--- a/pkg/http/core/kubernetes/rollback_test.go
+++ b/pkg/http/core/kubernetes/rollback_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Rollback", func() {
 
 	When("listing replicasets returns an error", func() {
 		BeforeEach(func() {
-			fakeKubeClient.ListReturns(nil, errors.New("error listing replicasets"))
+			fakeKubeClient.ListByGVRReturns(nil, errors.New("error listing replicasets"))
 		})
 
 		It("returns an error", func() {

--- a/pkg/http/core/manifest.go
+++ b/pkg/http/core/manifest.go
@@ -2,8 +2,10 @@ package core
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	clouddriver "github.com/billiford/go-clouddriver/pkg"
@@ -12,7 +14,13 @@ import (
 	"github.com/billiford/go-clouddriver/pkg/kubernetes"
 	"github.com/billiford/go-clouddriver/pkg/sql"
 	"github.com/gin-gonic/gin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
+)
+
+var (
+	listTimeout = int64(30)
 )
 
 func GetManifest(c *gin.Context) {
@@ -21,7 +29,9 @@ func GetManifest(c *gin.Context) {
 	ac := arcade.Instance(c)
 	account := c.Param("account")
 	namespace := c.Param("location")
-	n := c.Param("name")
+	// The name of this param should really be "id" or "cluster" as it represents a Spinnaker cluster, such as "deployment my-deployment".
+	// However, we have to make this path param match because of an underlying httprouter issue https://github.com/gin-gonic/gin/issues/2016.
+	n := c.Param("kind")
 	a := strings.Split(n, " ")
 	kind := a[0]
 	name := a[1]
@@ -73,9 +83,9 @@ func GetManifest(c *gin.Context) {
 
 	app := "unknown"
 	labels := result.GetLabels()
-	// TODO which label should we use here?
-	if _, ok := labels[kubernetes.LabelKubernetesSpinnakerApp]; ok {
-		app = labels[kubernetes.LabelKubernetesSpinnakerApp]
+
+	if _, ok := labels[kubernetes.LabelKubernetesName]; ok {
+		app = labels[kubernetes.LabelKubernetesName]
 	}
 
 	kmr := ops.ManifestResponse{
@@ -95,4 +105,146 @@ func GetManifest(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, kmr)
+}
+
+func GetManifestByTarget(c *gin.Context) {
+	sc := sql.Instance(c)
+	kc := kubernetes.ControllerInstance(c)
+	ac := arcade.Instance(c)
+	account := c.Param("account")
+	application := c.Param("application")
+	namespace := c.Param("location")
+	kind := c.Param("kind")
+	cluster := c.Param("cluster")
+	// Target can be newest, second_newest, oldest, largest, smallest.
+	target := c.Param("target")
+
+	// Sometimes a full kind such as MutatingWebhookConfiguration.admissionregistration.k8s.io
+	// is passed in - this is the current fix for that...
+	if strings.Index(kind, ".") > -1 {
+		a2 := strings.Split(kind, ".")
+		kind = a2[0]
+	}
+
+	provider, err := sc.GetKubernetesProvider(account)
+	if err != nil {
+		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
+	if err != nil {
+		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	token, err := ac.Token()
+	if err != nil {
+		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	config := &rest.Config{
+		Host:        provider.Host,
+		BearerToken: token,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: cd,
+		},
+	}
+
+	client, err := kc.NewClient(config)
+	if err != nil {
+		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	gvr, err := client.GVRForKind(kind)
+	if err != nil {
+		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	lo := metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kind,
+			APIVersion: gvr.Group + "/" + gvr.Version,
+		},
+		LabelSelector:  kubernetes.LabelKubernetesName + "=" + application,
+		FieldSelector:  "metadata.namespace=" + namespace,
+		TimeoutSeconds: &listTimeout,
+		// Limit:          0,
+	}
+
+	list, err := client.ListByGVR(gvr, lo)
+	if err != nil {
+		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	// Filter out all unassociated objects based on the moniker.spinnaker.io/cluster annotation.
+	items := filterOnCluster(list.Items, cluster)
+	if len(items) == 0 {
+		clouddriver.WriteError(c, http.StatusNotFound, errors.New("no resources found for cluster "+cluster))
+		return
+	}
+
+	// For now, we sort on creation timestamp to grab the manifest.
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].GetCreationTimestamp().String() > items[j].GetCreationTimestamp().String()
+	})
+
+	var result = items[0]
+
+	// Target can be newest, second_newest, oldest, largest, smallest.
+	// TODO fill in for largest and smallest targets.
+	switch strings.ToLower(target) {
+	case "newest":
+		result = items[0]
+	case "second_newest":
+		if len(items) < 2 {
+			clouddriver.WriteError(c, http.StatusBadRequest, errors.New("requested target \"Second Newest\" for cluster "+cluster+", but only one resource was found"))
+			return
+		}
+		result = items[1]
+	case "oldest":
+		if len(items) < 2 {
+			clouddriver.WriteError(c, http.StatusBadRequest, errors.New("requested target \"Oldest\" for cluster "+cluster+", but only one resource was found"))
+			return
+		}
+		result = items[len(items)-1]
+	default:
+		clouddriver.WriteError(c, http.StatusNotImplemented, errors.New("requested target \""+target+"\" for cluster "+cluster+" is not supported"))
+		return
+	}
+
+	kmr := ops.ManifestResponse{
+		Account:  account,
+		Events:   []interface{}{},
+		Location: namespace,
+		Manifest: result.Object,
+		Metrics:  []interface{}{},
+		Moniker: ops.ManifestResponseMoniker{
+			App:     application,
+			Cluster: cluster,
+		},
+		Name:     fmt.Sprintf("%s %s", kind, result.GetName()),
+		Status:   kubernetes.GetStatus(kind, result.Object),
+		Warnings: []interface{}{},
+	}
+
+	c.JSON(http.StatusOK, kmr)
+}
+
+func filterOnCluster(items []unstructured.Unstructured, cluster string) []unstructured.Unstructured {
+	filtered := []unstructured.Unstructured{}
+	for _, item := range items {
+		annotations := item.GetAnnotations()
+		if annotations != nil {
+			if strings.EqualFold(annotations[kubernetes.AnnotationSpinnakerMonikerCluster], cluster) {
+				filtered = append(filtered, item)
+			}
+		}
+	}
+
+	return filtered
 }

--- a/pkg/http/core/manifest_test.go
+++ b/pkg/http/core/manifest_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/billiford/go-clouddriver/pkg/kubernetes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var _ = Describe("Manifest", func() {
@@ -55,6 +57,20 @@ var _ = Describe("Manifest", func() {
 			})
 		})
 
+		When("getting the gcloud token returns an error", func() {
+			BeforeEach(func() {
+				fakeArcadeClient.TokenReturns("", errors.New("error getting token"))
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Message).To(Equal("error getting token"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
 		When("creating the kube client returns an error", func() {
 			BeforeEach(func() {
 				fakeKubeController.NewClientReturns(nil, errors.New("bad config"))
@@ -80,6 +96,223 @@ var _ = Describe("Manifest", func() {
 				Expect(ce.Error).To(Equal("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting manifest"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("it succeeds", func() {
+			It("succeeds", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			})
+		})
+	})
+
+	Describe("#GetManifestByTarget", func() {
+		var target string
+
+		BeforeEach(func() {
+			setup()
+			target = "newest"
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		JustBeforeEach(func() {
+			uri = svr.URL + "/manifests/test-account/test-namespace/test-kind/cluster/test-app/deployment test-deployment/dynamic/" + target
+			createRequest(http.MethodGet)
+			doRequest()
+		})
+
+		When("getting the provider returns an error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Message).To(Equal("error getting provider"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("there is an error decoding the provider CA data", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{
+					CAData: "@#$%",
+				}, nil)
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Message).To(Equal("illegal base64 data at input byte 0"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("getting the gcloud token returns an error", func() {
+			BeforeEach(func() {
+				fakeArcadeClient.TokenReturns("", errors.New("error getting token"))
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Message).To(Equal("error getting token"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("creating the kube client returns an error", func() {
+			BeforeEach(func() {
+				fakeKubeController.NewClientReturns(nil, errors.New("bad config"))
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Message).To(Equal("bad config"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("getting the gvr returns an error", func() {
+			BeforeEach(func() {
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{}, errors.New("error getting gvr"))
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Message).To(Equal("error getting gvr"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("listing resources returns an error", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListByGVRReturns(nil, errors.New("error listing resources"))
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Message).To(Equal("error listing resources"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("there are no resources found", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{}, nil)
+			})
+
+			It("returns status not found", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Not Found"))
+				Expect(ce.Message).To(Equal("no resources found for cluster deployment test-deployment"))
+				Expect(ce.Status).To(Equal(http.StatusNotFound))
+			})
+		})
+
+		Context("target is second_newest", func() {
+			BeforeEach(func() {
+				target = "second_newest"
+			})
+
+			When("there are less than two resources returned", func() {
+				BeforeEach(func() {
+					fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"annotations": map[string]interface{}{
+											kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+										},
+									},
+								},
+							},
+						},
+					}, nil)
+				})
+
+				It("returns an error", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+					ce := getClouddriverError()
+					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Message).To(Equal("requested target \"Second Newest\" for cluster deployment test-deployment, but only one resource was found"))
+					Expect(ce.Status).To(Equal(http.StatusBadRequest))
+				})
+			})
+
+			When("it succeeds", func() {
+				It("succeeds", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+				})
+			})
+		})
+
+		Context("target is oldest", func() {
+			BeforeEach(func() {
+				target = "oldest"
+			})
+
+			When("there are less than two resources returned", func() {
+				BeforeEach(func() {
+					fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"annotations": map[string]interface{}{
+											kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+										},
+									},
+								},
+							},
+						},
+					}, nil)
+				})
+
+				It("returns an error", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+					ce := getClouddriverError()
+					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Message).To(Equal("requested target \"Oldest\" for cluster deployment test-deployment, but only one resource was found"))
+					Expect(ce.Status).To(Equal(http.StatusBadRequest))
+				})
+			})
+
+			When("it succeeds", func() {
+				It("succeeds", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+				})
+			})
+		})
+
+		Context("the target is not supported", func() {
+			BeforeEach(func() {
+				target = "not_supported"
+			})
+
+			When("returns an error", func() {
+				It("succeeds", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusNotImplemented))
+					ce := getClouddriverError()
+					Expect(ce.Error).To(Equal("Not Implemented"))
+					Expect(ce.Message).To(Equal("requested target \"not_supported\" for cluster deployment test-deployment is not supported"))
+					Expect(ce.Status).To(Equal(http.StatusNotImplemented))
+				})
 			})
 		})
 

--- a/pkg/http/core/ops.go
+++ b/pkg/http/core/ops.go
@@ -24,8 +24,8 @@ import (
 // this function a bit more readable.
 func CreateKubernetesOperation(c *gin.Context) {
 	// All operations are bound to a task ID and stored in the database.
-	taskID := uuid.New().String()
 	ko := kubernetes.Operations{}
+	taskID := uuid.New().String()
 	ac := arcade.Instance(c)
 	ah := kubernetes.ActionHandlerInstance(c)
 	kc := kube.ControllerInstance(c)
@@ -94,6 +94,14 @@ func CreateKubernetesOperation(c *gin.Context) {
 
 		if req.UndoRolloutManifest != nil {
 			err = ah.NewRollbackAction(config).Run()
+			if err != nil {
+				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				return
+			}
+		}
+
+		if req.PatchManifest != nil {
+			err = ah.NewPatchManifestAction(config).Run()
 			if err != nil {
 				clouddriver.WriteError(c, http.StatusInternalServerError, err)
 				return

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -29,23 +29,24 @@ func Initialize(r *gin.Engine) {
 		api.GET("/applications/:application/clusters", core.ListClusters)
 
 		// Create a kubernetes operation - deploy/delete/scale manifest.
-		r.POST("/kubernetes/ops", core.CreateKubernetesOperation)
+		api.POST("/kubernetes/ops", core.CreateKubernetesOperation)
 
-		// Monitor deploy.
-		r.GET("/manifests/:account/:location/:name", core.GetManifest)
+		// Manifests API controller.
+		api.GET("/manifests/:account/:location/:kind", core.GetManifest)
+		api.GET("/manifests/:account/:location/:kind/cluster/:application/:cluster/dynamic/:target", core.GetManifestByTarget)
 
 		// Get results for a task triggered in CreateKubernetesOperation.
-		r.GET("/task/:id", core.GetTask)
+		api.GET("/task/:id", core.GetTask)
 
 		// Not implemented.
-		r.GET("/securityGroups", core.ListSecurityGroups)
-		r.GET("/search", core.Search)
+		api.GET("/securityGroups", core.ListSecurityGroups)
+		api.GET("/search", core.Search)
 
-		// Artifacts controller.
-		r.GET("/artifacts/credentials", core.ListArtifactCredentials)
-		r.GET("/artifacts/account/:accountName/names", core.ListHelmArtifactAccountNames)
-		r.GET("/artifacts/account/:accountName/versions", core.ListHelmArtifactAccountVersions)
-		r.PUT("/artifacts/fetch/", core.GetArtifact)
+		// Artifacts API controller.
+		api.GET("/artifacts/credentials", core.ListArtifactCredentials)
+		api.GET("/artifacts/account/:accountName/names", core.ListHelmArtifactAccountNames)
+		api.GET("/artifacts/account/:accountName/versions", core.ListHelmArtifactAccountVersions)
+		api.PUT("/artifacts/fetch/", core.GetArtifact)
 	}
 
 	// New endpoint.

--- a/pkg/kubernetes/deployment.go
+++ b/pkg/kubernetes/deployment.go
@@ -23,6 +23,7 @@ type Deployment interface {
 	GetSpec() v1.DeploymentSpec
 	SetReplicas(*int32)
 	LabelTemplate(string, string)
+	LabelTemplateIfNotExists(string, string)
 	Status() manifest.Status
 	Object() *v1.Deployment
 }
@@ -76,6 +77,18 @@ func (d *deployment) LabelTemplate(key, value string) {
 	}
 
 	labels[key] = value
+	d.d.Spec.Template.ObjectMeta.Labels = labels
+}
+
+func (d *deployment) LabelTemplateIfNotExists(key, value string) {
+	labels := d.d.Spec.Template.ObjectMeta.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	if _, ok := labels[key]; !ok {
+		labels[key] = value
+	}
 	d.d.Spec.Template.ObjectMeta.Labels = labels
 }
 

--- a/pkg/kubernetes/deployment_test.go
+++ b/pkg/kubernetes/deployment_test.go
@@ -82,6 +82,35 @@ var _ = Describe("Deployment", func() {
 		})
 	})
 
+	Describe("#LabelTemplateIfNotExists", func() {
+		JustBeforeEach(func() {
+			deployment.LabelTemplateIfNotExists("test", "value")
+		})
+
+		When("the label exists", func() {
+			BeforeEach(func() {
+				o := deployment.Object()
+				o.Spec.Template.ObjectMeta.Labels = map[string]string{
+					"test": "taken",
+				}
+			})
+
+			It("does not label the template", func() {
+				o := deployment.Object()
+				labels := o.Spec.Template.ObjectMeta.Labels
+				Expect(labels["test"]).To(Equal("taken"))
+			})
+		})
+
+		When("it succeeds", func() {
+			It("succeeds", func() {
+				o := deployment.Object()
+				labels := o.Spec.Template.ObjectMeta.Labels
+				Expect(labels["test"]).To(Equal("value"))
+			})
+		})
+	})
+
 	Describe("#SetReplicas", func() {
 		BeforeEach(func() {
 			replicas := int32(4)

--- a/pkg/kubernetes/kubernetesfakes/fake_client.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_client.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type FakeClient struct {
@@ -38,6 +39,19 @@ type FakeClient struct {
 		result1 kubernetes.Metadata
 		result2 error
 	}
+	GVRForKindStub        func(string) (schema.GroupVersionResource, error)
+	gVRForKindMutex       sync.RWMutex
+	gVRForKindArgsForCall []struct {
+		arg1 string
+	}
+	gVRForKindReturns struct {
+		result1 schema.GroupVersionResource
+		result2 error
+	}
+	gVRForKindReturnsOnCall map[int]struct {
+		result1 schema.GroupVersionResource
+		result2 error
+	}
 	GetStub        func(string, string, string) (*unstructured.Unstructured, error)
 	getMutex       sync.RWMutex
 	getArgsForCall []struct {
@@ -53,19 +67,56 @@ type FakeClient struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	ListStub        func(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
-	listMutex       sync.RWMutex
-	listArgsForCall []struct {
+	ListByGVRStub        func(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	listByGVRMutex       sync.RWMutex
+	listByGVRArgsForCall []struct {
 		arg1 schema.GroupVersionResource
 		arg2 metav1.ListOptions
 	}
-	listReturns struct {
+	listByGVRReturns struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}
-	listReturnsOnCall map[int]struct {
+	listByGVRReturnsOnCall map[int]struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
+	}
+	PatchStub        func(string, string, string, []byte) (kubernetes.Metadata, *unstructured.Unstructured, error)
+	patchMutex       sync.RWMutex
+	patchArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 []byte
+	}
+	patchReturns struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
+	}
+	patchReturnsOnCall map[int]struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
+	}
+	PatchUsingStrategyStub        func(string, string, string, []byte, types.PatchType) (kubernetes.Metadata, *unstructured.Unstructured, error)
+	patchUsingStrategyMutex       sync.RWMutex
+	patchUsingStrategyArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 []byte
+		arg5 types.PatchType
+	}
+	patchUsingStrategyReturns struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
+	}
+	patchUsingStrategyReturnsOnCall map[int]struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -174,6 +225,57 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 k
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GVRForKind(arg1 string) (schema.GroupVersionResource, error) {
+	fake.gVRForKindMutex.Lock()
+	ret, specificReturn := fake.gVRForKindReturnsOnCall[len(fake.gVRForKindArgsForCall)]
+	fake.gVRForKindArgsForCall = append(fake.gVRForKindArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GVRForKind", []interface{}{arg1})
+	fake.gVRForKindMutex.Unlock()
+	if fake.GVRForKindStub != nil {
+		return fake.GVRForKindStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.gVRForKindReturns.result1, fake.gVRForKindReturns.result2
+}
+
+func (fake *FakeClient) GVRForKindCallCount() int {
+	fake.gVRForKindMutex.RLock()
+	defer fake.gVRForKindMutex.RUnlock()
+	return len(fake.gVRForKindArgsForCall)
+}
+
+func (fake *FakeClient) GVRForKindArgsForCall(i int) string {
+	fake.gVRForKindMutex.RLock()
+	defer fake.gVRForKindMutex.RUnlock()
+	return fake.gVRForKindArgsForCall[i].arg1
+}
+
+func (fake *FakeClient) GVRForKindReturns(result1 schema.GroupVersionResource, result2 error) {
+	fake.GVRForKindStub = nil
+	fake.gVRForKindReturns = struct {
+		result1 schema.GroupVersionResource
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GVRForKindReturnsOnCall(i int, result1 schema.GroupVersionResource, result2 error) {
+	fake.GVRForKindStub = nil
+	if fake.gVRForKindReturnsOnCall == nil {
+		fake.gVRForKindReturnsOnCall = make(map[int]struct {
+			result1 schema.GroupVersionResource
+			result2 error
+		})
+	}
+	fake.gVRForKindReturnsOnCall[i] = struct {
+		result1 schema.GroupVersionResource
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Get(arg1 string, arg2 string, arg3 string) (*unstructured.Unstructured, error) {
 	fake.getMutex.Lock()
 	ret, specificReturn := fake.getReturnsOnCall[len(fake.getArgsForCall)]
@@ -227,56 +329,181 @@ func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructur
 	}{result1, result2}
 }
 
-func (fake *FakeClient) List(arg1 schema.GroupVersionResource, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-	fake.listMutex.Lock()
-	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
-	fake.listArgsForCall = append(fake.listArgsForCall, struct {
+func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	fake.listByGVRMutex.Lock()
+	ret, specificReturn := fake.listByGVRReturnsOnCall[len(fake.listByGVRArgsForCall)]
+	fake.listByGVRArgsForCall = append(fake.listByGVRArgsForCall, struct {
 		arg1 schema.GroupVersionResource
 		arg2 metav1.ListOptions
 	}{arg1, arg2})
-	fake.recordInvocation("List", []interface{}{arg1, arg2})
-	fake.listMutex.Unlock()
-	if fake.ListStub != nil {
-		return fake.ListStub(arg1, arg2)
+	fake.recordInvocation("ListByGVR", []interface{}{arg1, arg2})
+	fake.listByGVRMutex.Unlock()
+	if fake.ListByGVRStub != nil {
+		return fake.ListByGVRStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listReturns.result1, fake.listReturns.result2
+	return fake.listByGVRReturns.result1, fake.listByGVRReturns.result2
 }
 
-func (fake *FakeClient) ListCallCount() int {
-	fake.listMutex.RLock()
-	defer fake.listMutex.RUnlock()
-	return len(fake.listArgsForCall)
+func (fake *FakeClient) ListByGVRCallCount() int {
+	fake.listByGVRMutex.RLock()
+	defer fake.listByGVRMutex.RUnlock()
+	return len(fake.listByGVRArgsForCall)
 }
 
-func (fake *FakeClient) ListArgsForCall(i int) (schema.GroupVersionResource, metav1.ListOptions) {
-	fake.listMutex.RLock()
-	defer fake.listMutex.RUnlock()
-	return fake.listArgsForCall[i].arg1, fake.listArgsForCall[i].arg2
+func (fake *FakeClient) ListByGVRArgsForCall(i int) (schema.GroupVersionResource, metav1.ListOptions) {
+	fake.listByGVRMutex.RLock()
+	defer fake.listByGVRMutex.RUnlock()
+	return fake.listByGVRArgsForCall[i].arg1, fake.listByGVRArgsForCall[i].arg2
 }
 
-func (fake *FakeClient) ListReturns(result1 *unstructured.UnstructuredList, result2 error) {
-	fake.ListStub = nil
-	fake.listReturns = struct {
+func (fake *FakeClient) ListByGVRReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.ListByGVRStub = nil
+	fake.listByGVRReturns = struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
-	fake.ListStub = nil
-	if fake.listReturnsOnCall == nil {
-		fake.listReturnsOnCall = make(map[int]struct {
+func (fake *FakeClient) ListByGVRReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.ListByGVRStub = nil
+	if fake.listByGVRReturnsOnCall == nil {
+		fake.listByGVRReturnsOnCall = make(map[int]struct {
 			result1 *unstructured.UnstructuredList
 			result2 error
 		})
 	}
-	fake.listReturnsOnCall[i] = struct {
+	fake.listByGVRReturnsOnCall[i] = struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClient) Patch(arg1 string, arg2 string, arg3 string, arg4 []byte) (kubernetes.Metadata, *unstructured.Unstructured, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
+	}
+	fake.patchMutex.Lock()
+	ret, specificReturn := fake.patchReturnsOnCall[len(fake.patchArgsForCall)]
+	fake.patchArgsForCall = append(fake.patchArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 []byte
+	}{arg1, arg2, arg3, arg4Copy})
+	fake.recordInvocation("Patch", []interface{}{arg1, arg2, arg3, arg4Copy})
+	fake.patchMutex.Unlock()
+	if fake.PatchStub != nil {
+		return fake.PatchStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fake.patchReturns.result1, fake.patchReturns.result2, fake.patchReturns.result3
+}
+
+func (fake *FakeClient) PatchCallCount() int {
+	fake.patchMutex.RLock()
+	defer fake.patchMutex.RUnlock()
+	return len(fake.patchArgsForCall)
+}
+
+func (fake *FakeClient) PatchArgsForCall(i int) (string, string, string, []byte) {
+	fake.patchMutex.RLock()
+	defer fake.patchMutex.RUnlock()
+	return fake.patchArgsForCall[i].arg1, fake.patchArgsForCall[i].arg2, fake.patchArgsForCall[i].arg3, fake.patchArgsForCall[i].arg4
+}
+
+func (fake *FakeClient) PatchReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.PatchStub = nil
+	fake.patchReturns = struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) PatchReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.PatchStub = nil
+	if fake.patchReturnsOnCall == nil {
+		fake.patchReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Metadata
+			result2 *unstructured.Unstructured
+			result3 error
+		})
+	}
+	fake.patchReturnsOnCall[i] = struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) PatchUsingStrategy(arg1 string, arg2 string, arg3 string, arg4 []byte, arg5 types.PatchType) (kubernetes.Metadata, *unstructured.Unstructured, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
+	}
+	fake.patchUsingStrategyMutex.Lock()
+	ret, specificReturn := fake.patchUsingStrategyReturnsOnCall[len(fake.patchUsingStrategyArgsForCall)]
+	fake.patchUsingStrategyArgsForCall = append(fake.patchUsingStrategyArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 []byte
+		arg5 types.PatchType
+	}{arg1, arg2, arg3, arg4Copy, arg5})
+	fake.recordInvocation("PatchUsingStrategy", []interface{}{arg1, arg2, arg3, arg4Copy, arg5})
+	fake.patchUsingStrategyMutex.Unlock()
+	if fake.PatchUsingStrategyStub != nil {
+		return fake.PatchUsingStrategyStub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fake.patchUsingStrategyReturns.result1, fake.patchUsingStrategyReturns.result2, fake.patchUsingStrategyReturns.result3
+}
+
+func (fake *FakeClient) PatchUsingStrategyCallCount() int {
+	fake.patchUsingStrategyMutex.RLock()
+	defer fake.patchUsingStrategyMutex.RUnlock()
+	return len(fake.patchUsingStrategyArgsForCall)
+}
+
+func (fake *FakeClient) PatchUsingStrategyArgsForCall(i int) (string, string, string, []byte, types.PatchType) {
+	fake.patchUsingStrategyMutex.RLock()
+	defer fake.patchUsingStrategyMutex.RUnlock()
+	return fake.patchUsingStrategyArgsForCall[i].arg1, fake.patchUsingStrategyArgsForCall[i].arg2, fake.patchUsingStrategyArgsForCall[i].arg3, fake.patchUsingStrategyArgsForCall[i].arg4, fake.patchUsingStrategyArgsForCall[i].arg5
+}
+
+func (fake *FakeClient) PatchUsingStrategyReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.PatchUsingStrategyStub = nil
+	fake.patchUsingStrategyReturns = struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) PatchUsingStrategyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.PatchUsingStrategyStub = nil
+	if fake.patchUsingStrategyReturnsOnCall == nil {
+		fake.patchUsingStrategyReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Metadata
+			result2 *unstructured.Unstructured
+			result3 error
+		})
+	}
+	fake.patchUsingStrategyReturnsOnCall[i] = struct {
+		result1 kubernetes.Metadata
+		result2 *unstructured.Unstructured
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
@@ -286,10 +513,16 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.applyMutex.RUnlock()
 	fake.applyWithNamespaceOverrideMutex.RLock()
 	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
+	fake.gVRForKindMutex.RLock()
+	defer fake.gVRForKindMutex.RUnlock()
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
-	fake.listMutex.RLock()
-	defer fake.listMutex.RUnlock()
+	fake.listByGVRMutex.RLock()
+	defer fake.listByGVRMutex.RUnlock()
+	fake.patchMutex.RLock()
+	defer fake.patchMutex.RUnlock()
+	fake.patchUsingStrategyMutex.RLock()
+	defer fake.patchUsingStrategyMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/kubernetes/label_test.go
+++ b/pkg/kubernetes/label_test.go
@@ -25,56 +25,142 @@ var _ = Describe("Annotation", func() {
 	})
 
 	When("the object is a deployment", func() {
-		BeforeEach(func() {
-			m := map[string]interface{}{
-				"kind":       "Deployment",
-				"apiVersion": "apps/v1",
-				"metadata": map[string]interface{}{
-					"namespace": "default",
-					"name":      "test-name",
-				},
-			}
-			u, err = kc.ToUnstructured(m)
-			Expect(err).To(BeNil())
-			application = "test-application"
+		Context("the name label does not exist", func() {
+			BeforeEach(func() {
+				m := map[string]interface{}{
+					"kind":       "Deployment",
+					"apiVersion": "apps/v1",
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+						"name":      "test-name",
+					},
+				}
+				u, err = kc.ToUnstructured(m)
+				Expect(err).To(BeNil())
+				application = "test-application"
+			})
+
+			It("adds the labels", func() {
+				labels := u.GetLabels()
+				Expect(labels[LabelKubernetesName]).To(Equal(application))
+				Expect(labels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+
+				d := NewDeployment(u.Object).Object()
+				templateLabels := d.Spec.Template.ObjectMeta.Labels
+				Expect(templateLabels[LabelKubernetesName]).To(Equal(application))
+				Expect(templateLabels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+			})
 		})
 
-		It("adds the labels", func() {
-			labels := u.GetLabels()
-			Expect(labels[LabelKubernetesSpinnakerApp]).To(Equal(application))
-			Expect(labels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+		Context("the name label exists", func() {
+			BeforeEach(func() {
+				m := map[string]interface{}{
+					"kind":       "Deployment",
+					"apiVersion": "apps/v1",
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+						"name":      "test-name",
+						"labels": map[string]interface{}{
+							"app.kubernetes.io/name": "test-already-here",
+						},
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": "default",
+								"name":      "test-name",
+								"labels": map[string]interface{}{
+									"app.kubernetes.io/name": "test-already-here",
+								},
+							},
+						},
+					},
+				}
+				u, err = kc.ToUnstructured(m)
+				Expect(err).To(BeNil())
+				application = "test-application"
+			})
 
-			d := NewDeployment(u.Object).Object()
-			templateLabels := d.Spec.Template.ObjectMeta.Labels
-			Expect(templateLabels[LabelKubernetesSpinnakerApp]).To(Equal(application))
-			Expect(templateLabels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+			It("does not add the name label", func() {
+				labels := u.GetLabels()
+				Expect(labels[LabelKubernetesName]).To(Equal("test-already-here"))
+				Expect(labels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+
+				d := NewDeployment(u.Object).Object()
+				templateLabels := d.Spec.Template.ObjectMeta.Labels
+				Expect(templateLabels[LabelKubernetesName]).To(Equal("test-already-here"))
+				Expect(templateLabels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+			})
 		})
 	})
 
 	When("the object is a replicaset", func() {
-		BeforeEach(func() {
-			m := map[string]interface{}{
-				"kind":       "ReplicaSet",
-				"apiVersion": "apps/v1",
-				"metadata": map[string]interface{}{
-					"namespace": "default",
-					"name":      "test-name",
-				},
-			}
-			u, err = kc.ToUnstructured(m)
-			Expect(err).To(BeNil())
-			application = "test-application"
+		Context("the name label does not exist", func() {
+			BeforeEach(func() {
+				m := map[string]interface{}{
+					"kind":       "ReplicaSet",
+					"apiVersion": "apps/v1",
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+						"name":      "test-name",
+					},
+				}
+				u, err = kc.ToUnstructured(m)
+				Expect(err).To(BeNil())
+				application = "test-application"
+			})
+
+			It("adds the labels", func() {
+				labels := u.GetLabels()
+				Expect(labels[LabelKubernetesName]).To(Equal(application))
+				Expect(labels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+
+				d := NewDeployment(u.Object).Object()
+				templateLabels := d.Spec.Template.ObjectMeta.Labels
+				Expect(templateLabels[LabelKubernetesName]).To(Equal(application))
+				Expect(templateLabels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+			})
 		})
 
-		It("adds the labels", func() {
-			labels := u.GetLabels()
-			Expect(labels[LabelKubernetesSpinnakerApp]).To(Equal(application))
-			Expect(labels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+		Context("the name label exists", func() {
+			BeforeEach(func() {
+				m := map[string]interface{}{
+					"kind":       "ReplicaSet",
+					"apiVersion": "apps/v1",
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+						"name":      "test-name",
+						"labels": map[string]interface{}{
+							"app.kubernetes.io/name": "test-already-here",
+						},
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"namespace": "default",
+								"name":      "test-name",
+								"labels": map[string]interface{}{
+									"app.kubernetes.io/name": "test-already-here",
+								},
+							},
+						},
+					},
+				}
+				u, err = kc.ToUnstructured(m)
+				Expect(err).To(BeNil())
+				application = "test-application"
+			})
 
-			d := NewDeployment(u.Object).Object()
-			templateLabels := d.Spec.Template.ObjectMeta.Labels
-			Expect(templateLabels[LabelKubernetesSpinnakerApp]).To(Equal(application))
-			Expect(templateLabels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+			It("does not add the name label", func() {
+				labels := u.GetLabels()
+				Expect(labels[LabelKubernetesName]).To(Equal("test-already-here"))
+				Expect(labels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+
+				d := NewDeployment(u.Object).Object()
+				templateLabels := d.Spec.Template.ObjectMeta.Labels
+				Expect(templateLabels[LabelKubernetesName]).To(Equal("test-already-here"))
+				Expect(templateLabels[LabelKubernetesManagedBy]).To(Equal("spinnaker"))
+			})
 		})
 	})
 })

--- a/pkg/kubernetes/replicaset.go
+++ b/pkg/kubernetes/replicaset.go
@@ -14,6 +14,7 @@ type ReplicaSet interface {
 	GetReplicaSetSpec() v1.ReplicaSetSpec
 	GetReplicaSetStatus() v1.ReplicaSetStatus
 	LabelTemplate(string, string)
+	LabelTemplateIfNotExists(string, string)
 	Status() manifest.Status
 	SetReplicas(*int32)
 	ListImages() []string
@@ -69,6 +70,18 @@ func (rs *replicaSet) LabelTemplate(key, value string) {
 	}
 
 	labels[key] = value
+	rs.rs.Spec.Template.ObjectMeta.Labels = labels
+}
+
+func (rs *replicaSet) LabelTemplateIfNotExists(key, value string) {
+	labels := rs.rs.Spec.Template.ObjectMeta.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	if _, ok := labels[key]; !ok {
+		labels[key] = value
+	}
 	rs.rs.Spec.Template.ObjectMeta.Labels = labels
 }
 

--- a/pkg/kubernetes/replicaset_test.go
+++ b/pkg/kubernetes/replicaset_test.go
@@ -114,6 +114,35 @@ var _ = Describe("Replicaset", func() {
 		})
 	})
 
+	Describe("#LabelTemplateIfNotExists", func() {
+		JustBeforeEach(func() {
+			rs.LabelTemplateIfNotExists("test", "value")
+		})
+
+		When("the label exists", func() {
+			BeforeEach(func() {
+				o := rs.Object()
+				o.Spec.Template.ObjectMeta.Labels = map[string]string{
+					"test": "taken",
+				}
+			})
+
+			It("does not label the template", func() {
+				o := rs.Object()
+				labels := o.Spec.Template.ObjectMeta.Labels
+				Expect(labels["test"]).To(Equal("taken"))
+			})
+		})
+
+		When("it succeeds", func() {
+			It("succeeds", func() {
+				o := rs.Object()
+				labels := o.Spec.Template.ObjectMeta.Labels
+				Expect(labels["test"]).To(Equal("value"))
+			})
+		})
+	})
+
 	Describe("#Status", func() {
 		var s manifest.Status
 


### PR DESCRIPTION
This PR adds support for patch manifest.

- It supports all patch types in Spinnaker (strategic, json, and merge).
- It adds support to dynamically resolve newest, second newest, and oldest manifests.