### PR TITLE
use joins when listing credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/docker/docker-credential-helpers v0.6.3
 	github.com/fatih/color v1.9.0
+	github.com/gdexlab/go-render v1.0.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/gddo v0.0.0-20200715224205-051695c33a3f
@@ -14,6 +15,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0
 	github.com/lib/pq v1.2.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.0
+	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.3 // indirect
 	github.com/mcuadros/go-gin-prometheus v0.1.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/onsi/ginkgo v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/garyburd/redigo v1.1.1-0.20170914051019-70e1b1943d4f/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/gdexlab/go-render v1.0.1 h1:rxqB3vo5s4n1kF0ySmoNeSPRYkEsyHgln4jFIQY7v0U=
+github.com/gdexlab/go-render v1.0.1/go.mod h1:wRi5nW2qfjiGj4mPukH4UV0IknS1cHD4VgFTmJX5JzM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -366,6 +368,7 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -449,6 +452,8 @@ github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.2.3 h1:z1lXirM9f9WTcdmzSZahKh/t+LCqPiiwK2/DB1kLlI4=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.2.3/go.mod h1:1ftk08SazyElaaNvmqAfZWGwJzshjCfBXDLoQtPAMNk=
 github.com/mcuadros/go-gin-prometheus v0.1.0 h1:JNoWKvw/u9tyRJ8BL9ZJvfiXU8IHUw8gCvcf/5L8tnI=
 github.com/mcuadros/go-gin-prometheus v0.1.0/go.mod h1:ezECAsiHtCRIa+6Ii8THg7G7RJvpO4S19d499UkEE3s=
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
@@ -505,6 +510,7 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
@@ -557,6 +563,8 @@ github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -661,6 +669,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -678,6 +687,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20170915142106-8351a756f30f/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -701,6 +712,7 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -745,6 +757,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -802,7 +815,10 @@ golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190909030654-5b82db07426d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200301222351-066e0c02454c h1:FD7jysxM+EJqg5UYYy3XYDsAiUickFsn4UiaanJkf8c=
+golang.org/x/tools v0.0.0-20200301222351-066e0c02454c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=

--- a/pkg/arcade/arcadefakes/fake_client.go
+++ b/pkg/arcade/arcadefakes/fake_client.go
@@ -10,8 +10,9 @@ import (
 type FakeClient struct {
 	TokenStub        func() (string, error)
 	tokenMutex       sync.RWMutex
-	tokenArgsForCall []struct{}
-	tokenReturns     struct {
+	tokenArgsForCall []struct {
+	}
+	tokenReturns struct {
 		result1 string
 		result2 error
 	}
@@ -31,7 +32,8 @@ type FakeClient struct {
 func (fake *FakeClient) Token() (string, error) {
 	fake.tokenMutex.Lock()
 	ret, specificReturn := fake.tokenReturnsOnCall[len(fake.tokenArgsForCall)]
-	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct{}{})
+	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Token", []interface{}{})
 	fake.tokenMutex.Unlock()
 	if fake.TokenStub != nil {
@@ -40,7 +42,8 @@ func (fake *FakeClient) Token() (string, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.tokenReturns.result1, fake.tokenReturns.result2
+	fakeReturns := fake.tokenReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) TokenCallCount() int {
@@ -49,7 +52,15 @@ func (fake *FakeClient) TokenCallCount() int {
 	return len(fake.tokenArgsForCall)
 }
 
+func (fake *FakeClient) TokenCalls(stub func() (string, error)) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
+	fake.TokenStub = stub
+}
+
 func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	fake.tokenReturns = struct {
 		result1 string
@@ -58,6 +69,8 @@ func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeClient) TokenReturnsOnCall(i int, result1 string, result2 error) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	if fake.tokenReturnsOnCall == nil {
 		fake.tokenReturnsOnCall = make(map[int]struct {
@@ -89,10 +102,17 @@ func (fake *FakeClient) WithAPIKeyCallCount() int {
 	return len(fake.withAPIKeyArgsForCall)
 }
 
+func (fake *FakeClient) WithAPIKeyCalls(stub func(string)) {
+	fake.withAPIKeyMutex.Lock()
+	defer fake.withAPIKeyMutex.Unlock()
+	fake.WithAPIKeyStub = stub
+}
+
 func (fake *FakeClient) WithAPIKeyArgsForCall(i int) string {
 	fake.withAPIKeyMutex.RLock()
 	defer fake.withAPIKeyMutex.RUnlock()
-	return fake.withAPIKeyArgsForCall[i].arg1
+	argsForCall := fake.withAPIKeyArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) Invocations() map[string][][]interface{} {

--- a/pkg/helm/helmfakes/fake_client.go
+++ b/pkg/helm/helmfakes/fake_client.go
@@ -8,17 +8,6 @@ import (
 )
 
 type FakeClient struct {
-	GetIndexStub        func() (helm.Index, error)
-	getIndexMutex       sync.RWMutex
-	getIndexArgsForCall []struct{}
-	getIndexReturns     struct {
-		result1 helm.Index
-		result2 error
-	}
-	getIndexReturnsOnCall map[int]struct {
-		result1 helm.Index
-		result2 error
-	}
 	GetChartStub        func(string, string) ([]byte, error)
 	getChartMutex       sync.RWMutex
 	getChartArgsForCall []struct {
@@ -33,51 +22,20 @@ type FakeClient struct {
 		result1 []byte
 		result2 error
 	}
+	GetIndexStub        func() (helm.Index, error)
+	getIndexMutex       sync.RWMutex
+	getIndexArgsForCall []struct {
+	}
+	getIndexReturns struct {
+		result1 helm.Index
+		result2 error
+	}
+	getIndexReturnsOnCall map[int]struct {
+		result1 helm.Index
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeClient) GetIndex() (helm.Index, error) {
-	fake.getIndexMutex.Lock()
-	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
-	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct{}{})
-	fake.recordInvocation("GetIndex", []interface{}{})
-	fake.getIndexMutex.Unlock()
-	if fake.GetIndexStub != nil {
-		return fake.GetIndexStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.getIndexReturns.result1, fake.getIndexReturns.result2
-}
-
-func (fake *FakeClient) GetIndexCallCount() int {
-	fake.getIndexMutex.RLock()
-	defer fake.getIndexMutex.RUnlock()
-	return len(fake.getIndexArgsForCall)
-}
-
-func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
-	fake.GetIndexStub = nil
-	fake.getIndexReturns = struct {
-		result1 helm.Index
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2 error) {
-	fake.GetIndexStub = nil
-	if fake.getIndexReturnsOnCall == nil {
-		fake.getIndexReturnsOnCall = make(map[int]struct {
-			result1 helm.Index
-			result2 error
-		})
-	}
-	fake.getIndexReturnsOnCall[i] = struct {
-		result1 helm.Index
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
@@ -95,7 +53,8 @@ func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getChartReturns.result1, fake.getChartReturns.result2
+	fakeReturns := fake.getChartReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GetChartCallCount() int {
@@ -104,13 +63,22 @@ func (fake *FakeClient) GetChartCallCount() int {
 	return len(fake.getChartArgsForCall)
 }
 
+func (fake *FakeClient) GetChartCalls(stub func(string, string) ([]byte, error)) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
+	fake.GetChartStub = stub
+}
+
 func (fake *FakeClient) GetChartArgsForCall(i int) (string, string) {
 	fake.getChartMutex.RLock()
 	defer fake.getChartMutex.RUnlock()
-	return fake.getChartArgsForCall[i].arg1, fake.getChartArgsForCall[i].arg2
+	argsForCall := fake.getChartArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
 	fake.GetChartStub = nil
 	fake.getChartReturns = struct {
 		result1 []byte
@@ -119,6 +87,8 @@ func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
 }
 
 func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
 	fake.GetChartStub = nil
 	if fake.getChartReturnsOnCall == nil {
 		fake.getChartReturnsOnCall = make(map[int]struct {
@@ -132,13 +102,68 @@ func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 err
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GetIndex() (helm.Index, error) {
+	fake.getIndexMutex.Lock()
+	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
+	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct {
+	}{})
+	fake.recordInvocation("GetIndex", []interface{}{})
+	fake.getIndexMutex.Unlock()
+	if fake.GetIndexStub != nil {
+		return fake.GetIndexStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getIndexReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetIndexCallCount() int {
+	fake.getIndexMutex.RLock()
+	defer fake.getIndexMutex.RUnlock()
+	return len(fake.getIndexArgsForCall)
+}
+
+func (fake *FakeClient) GetIndexCalls(stub func() (helm.Index, error)) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = stub
+}
+
+func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = nil
+	fake.getIndexReturns = struct {
+		result1 helm.Index
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2 error) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = nil
+	if fake.getIndexReturnsOnCall == nil {
+		fake.getIndexReturnsOnCall = make(map[int]struct {
+			result1 helm.Index
+			result2 error
+		})
+	}
+	fake.getIndexReturnsOnCall[i] = struct {
+		result1 helm.Index
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getIndexMutex.RLock()
-	defer fake.getIndexMutex.RUnlock()
 	fake.getChartMutex.RLock()
 	defer fake.getChartMutex.RUnlock()
+	fake.getIndexMutex.RLock()
+	defer fake.getIndexMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/http/core/credentials_test.go
+++ b/pkg/http/core/credentials_test.go
@@ -21,11 +21,11 @@ var _ = Describe("Credential", func() {
 				setup()
 				uri = svr.URL + "/credentials"
 				createRequest(http.MethodGet)
-				fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+				fakeSQLClient.ListKubernetesProvidersAndPermissionsReturns([]kubernetes.Provider{
 					{
 						Name:        "provider1",
 						Host:        "host1",
-						CAData:      "caData1",
+						CAData:      "dGVzdAo=",
 						BearerToken: "some.bearer.token",
 						Permissions: kubernetes.ProviderPermissions{
 							Read: []string{
@@ -39,7 +39,7 @@ var _ = Describe("Credential", func() {
 					{
 						Name:        "provider2",
 						Host:        "host2",
-						CAData:      "caData2",
+						CAData:      "dGVzdAo=",
 						BearerToken: "some.bearer.token2",
 						Permissions: kubernetes.ProviderPermissions{
 							Read: []string{
@@ -63,7 +63,7 @@ var _ = Describe("Credential", func() {
 
 			When("listing providers returns an error", func() {
 				BeforeEach(func() {
-					fakeSQLClient.ListKubernetesProvidersReturns(nil, errors.New("error listing providers"))
+					fakeSQLClient.ListKubernetesProvidersAndPermissionsReturns(nil, errors.New("error listing providers"))
 				})
 
 				It("returns an error", func() {
@@ -71,34 +71,6 @@ var _ = Describe("Credential", func() {
 					ce := getClouddriverError()
 					Expect(ce.Error).To(Equal("Internal Server Error"))
 					Expect(ce.Message).To(Equal("error listing providers"))
-					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
-				})
-			})
-
-			When("listing read groups returns an error", func() {
-				BeforeEach(func() {
-					fakeSQLClient.ListReadGroupsByAccountNameReturns(nil, errors.New("error listing read groups"))
-				})
-
-				It("returns an error", func() {
-					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
-					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
-					Expect(ce.Message).To(Equal("error listing read groups"))
-					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
-				})
-			})
-
-			When("listing write groups returns an error", func() {
-				BeforeEach(func() {
-					fakeSQLClient.ListWriteGroupsByAccountNameReturns(nil, errors.New("error listing write groups"))
-				})
-
-				It("returns an error", func() {
-					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
-					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
-					Expect(ce.Message).To(Equal("error listing write groups"))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
 			})
@@ -116,11 +88,11 @@ var _ = Describe("Credential", func() {
 				setup()
 				uri = svr.URL + "/credentials?expand=true"
 				createRequest(http.MethodGet)
-				fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+				fakeSQLClient.ListKubernetesProvidersAndPermissionsReturns([]kubernetes.Provider{
 					{
 						Name:        "provider1",
 						Host:        "host1",
-						CAData:      "caData1",
+						CAData:      "dGVzdAo=",
 						BearerToken: "some.bearer.token",
 						Permissions: kubernetes.ProviderPermissions{
 							Read: []string{
@@ -134,7 +106,7 @@ var _ = Describe("Credential", func() {
 					{
 						Name:        "provider2",
 						Host:        "host2",
-						CAData:      "caData2",
+						CAData:      "dGVzdAo=",
 						BearerToken: "some.bearer.token2",
 						Permissions: kubernetes.ProviderPermissions{
 							Read: []string{
@@ -177,7 +149,7 @@ var _ = Describe("Credential", func() {
 
 			When("listing providers returns an error", func() {
 				BeforeEach(func() {
-					fakeSQLClient.ListKubernetesProvidersReturns(nil, errors.New("error listing providers"))
+					fakeSQLClient.ListKubernetesProvidersAndPermissionsReturns(nil, errors.New("error listing providers"))
 				})
 
 				It("returns an error", func() {
@@ -189,37 +161,38 @@ var _ = Describe("Credential", func() {
 				})
 			})
 
-			When("listing read groups returns an error", func() {
+			When("decoding the ca data returns an error", func() {
 				BeforeEach(func() {
-					fakeSQLClient.ListReadGroupsByAccountNameReturns(nil, errors.New("error listing read groups"))
-				})
-
-				It("returns an error", func() {
-					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
-					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
-					Expect(ce.Message).To(Equal("error listing read groups"))
-					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
-				})
-			})
-
-			When("listing write groups returns an error", func() {
-				BeforeEach(func() {
-					fakeSQLClient.ListWriteGroupsByAccountNameReturns(nil, errors.New("error listing write groups"))
-				})
-
-				It("returns an error", func() {
-					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
-					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
-					Expect(ce.Message).To(Equal("error listing write groups"))
-					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
-				})
-			})
-
-			When("getting the kubernetes provider returns an error", func() {
-				BeforeEach(func() {
-					fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting kubernetes provider"))
+					fakeSQLClient.ListKubernetesProvidersAndPermissionsReturns([]kubernetes.Provider{
+						{
+							Name:        "provider1",
+							Host:        "host1",
+							CAData:      "{}",
+							BearerToken: "some.bearer.token",
+							Permissions: kubernetes.ProviderPermissions{
+								Read: []string{
+									"gg_test",
+								},
+								Write: []string{
+									"gg_test",
+								},
+							},
+						},
+						{
+							Name:        "provider2",
+							Host:        "host2",
+							CAData:      "{}",
+							BearerToken: "some.bearer.token2",
+							Permissions: kubernetes.ProviderPermissions{
+								Read: []string{
+									"gg_test2",
+								},
+								Write: []string{
+									"gg_test2",
+								},
+							},
+						},
+					}, nil)
 				})
 
 				It("continues", func() {
@@ -228,15 +201,14 @@ var _ = Describe("Credential", func() {
 				})
 			})
 
-			When("decoding the ca data returns an error", func() {
+			When("getting the gcloud token returns an error", func() {
 				BeforeEach(func() {
-					fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{
-						CAData: "{}",
-					}, nil)
+					fakeArcadeClient.TokenReturns("", errors.New("error getting token"))
 				})
 
 				It("continues", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					Expect(fakeArcadeClient.TokenCallCount()).To(Equal(2))
 					validateResponse(payloadCredentialsExpandTrueNoNamespaces)
 				})
 			})
@@ -248,6 +220,7 @@ var _ = Describe("Credential", func() {
 
 				It("continues", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					Expect(fakeKubeController.NewClientCallCount()).To(Equal(2))
 					validateResponse(payloadCredentialsExpandTrueNoNamespaces)
 				})
 			})
@@ -259,6 +232,7 @@ var _ = Describe("Credential", func() {
 
 				It("continues", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					Expect(fakeKubeClient.ListCallCount()).To(Equal(2))
 					validateResponse(payloadCredentialsExpandTrueNoNamespaces)
 				})
 			})
@@ -281,7 +255,7 @@ var _ = Describe("Credential", func() {
 				{
 					Name:        "provider1",
 					Host:        "host1",
-					CAData:      "caData1",
+					CAData:      "dGVzdAo=",
 					BearerToken: "some.bearer.token",
 					Permissions: kubernetes.ProviderPermissions{
 						Read: []string{
@@ -295,7 +269,7 @@ var _ = Describe("Credential", func() {
 				{
 					Name:        "provider2",
 					Host:        "host2",
-					CAData:      "caData2",
+					CAData:      "dGVzdAo=",
 					BearerToken: "some.bearer.token2",
 					Permissions: kubernetes.ProviderPermissions{
 						Read: []string{

--- a/pkg/http/core/credentials_test.go
+++ b/pkg/http/core/credentials_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Credential", func() {
 
 				It("continues", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusOK))
-					Expect(fakeKubeClient.ListCallCount()).To(Equal(2))
+					Expect(fakeKubeClient.ListByGVRCallCount()).To(Equal(2))
 					validateResponse(payloadCredentialsExpandTrueNoNamespaces)
 				})
 			})

--- a/pkg/http/core/kubernetes/kubernetesfakes/fake_action.go
+++ b/pkg/http/core/kubernetes/kubernetesfakes/fake_action.go
@@ -10,8 +10,9 @@ import (
 type FakeAction struct {
 	RunStub        func() error
 	runMutex       sync.RWMutex
-	runArgsForCall []struct{}
-	runReturns     struct {
+	runArgsForCall []struct {
+	}
+	runReturns struct {
 		result1 error
 	}
 	runReturnsOnCall map[int]struct {
@@ -24,7 +25,8 @@ type FakeAction struct {
 func (fake *FakeAction) Run() error {
 	fake.runMutex.Lock()
 	ret, specificReturn := fake.runReturnsOnCall[len(fake.runArgsForCall)]
-	fake.runArgsForCall = append(fake.runArgsForCall, struct{}{})
+	fake.runArgsForCall = append(fake.runArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Run", []interface{}{})
 	fake.runMutex.Unlock()
 	if fake.RunStub != nil {
@@ -33,7 +35,8 @@ func (fake *FakeAction) Run() error {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.runReturns.result1
+	fakeReturns := fake.runReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeAction) RunCallCount() int {
@@ -42,7 +45,15 @@ func (fake *FakeAction) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
+func (fake *FakeAction) RunCalls(stub func() error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
+	fake.RunStub = stub
+}
+
 func (fake *FakeAction) RunReturns(result1 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	fake.runReturns = struct {
 		result1 error
@@ -50,6 +61,8 @@ func (fake *FakeAction) RunReturns(result1 error) {
 }
 
 func (fake *FakeAction) RunReturnsOnCall(i int, result1 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	if fake.runReturnsOnCall == nil {
 		fake.runReturnsOnCall = make(map[int]struct {

--- a/pkg/http/core/kubernetes/kubernetesfakes/fake_action_handler.go
+++ b/pkg/http/core/kubernetes/kubernetesfakes/fake_action_handler.go
@@ -19,17 +19,6 @@ type FakeActionHandler struct {
 	newDeployManifestActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
-	NewRollingRestartActionStub        func(kubernetes.ActionConfig) kubernetes.Action
-	newRollingRestartActionMutex       sync.RWMutex
-	newRollingRestartActionArgsForCall []struct {
-		arg1 kubernetes.ActionConfig
-	}
-	newRollingRestartActionReturns struct {
-		result1 kubernetes.Action
-	}
-	newRollingRestartActionReturnsOnCall map[int]struct {
-		result1 kubernetes.Action
-	}
 	NewRollbackActionStub        func(kubernetes.ActionConfig) kubernetes.Action
 	newRollbackActionMutex       sync.RWMutex
 	newRollbackActionArgsForCall []struct {
@@ -39,6 +28,17 @@ type FakeActionHandler struct {
 		result1 kubernetes.Action
 	}
 	newRollbackActionReturnsOnCall map[int]struct {
+		result1 kubernetes.Action
+	}
+	NewRollingRestartActionStub        func(kubernetes.ActionConfig) kubernetes.Action
+	newRollingRestartActionMutex       sync.RWMutex
+	newRollingRestartActionArgsForCall []struct {
+		arg1 kubernetes.ActionConfig
+	}
+	newRollingRestartActionReturns struct {
+		result1 kubernetes.Action
+	}
+	newRollingRestartActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
 	NewRunJobActionStub        func(kubernetes.ActionConfig) kubernetes.Action
@@ -81,7 +81,8 @@ func (fake *FakeActionHandler) NewDeployManifestAction(arg1 kubernetes.ActionCon
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newDeployManifestActionReturns.result1
+	fakeReturns := fake.newDeployManifestActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewDeployManifestActionCallCount() int {
@@ -90,13 +91,22 @@ func (fake *FakeActionHandler) NewDeployManifestActionCallCount() int {
 	return len(fake.newDeployManifestActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewDeployManifestActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newDeployManifestActionMutex.Lock()
+	defer fake.newDeployManifestActionMutex.Unlock()
+	fake.NewDeployManifestActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewDeployManifestActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newDeployManifestActionMutex.RLock()
 	defer fake.newDeployManifestActionMutex.RUnlock()
-	return fake.newDeployManifestActionArgsForCall[i].arg1
+	argsForCall := fake.newDeployManifestActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewDeployManifestActionReturns(result1 kubernetes.Action) {
+	fake.newDeployManifestActionMutex.Lock()
+	defer fake.newDeployManifestActionMutex.Unlock()
 	fake.NewDeployManifestActionStub = nil
 	fake.newDeployManifestActionReturns = struct {
 		result1 kubernetes.Action
@@ -104,6 +114,8 @@ func (fake *FakeActionHandler) NewDeployManifestActionReturns(result1 kubernetes
 }
 
 func (fake *FakeActionHandler) NewDeployManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newDeployManifestActionMutex.Lock()
+	defer fake.newDeployManifestActionMutex.Unlock()
 	fake.NewDeployManifestActionStub = nil
 	if fake.newDeployManifestActionReturnsOnCall == nil {
 		fake.newDeployManifestActionReturnsOnCall = make(map[int]struct {
@@ -111,54 +123,6 @@ func (fake *FakeActionHandler) NewDeployManifestActionReturnsOnCall(i int, resul
 		})
 	}
 	fake.newDeployManifestActionReturnsOnCall[i] = struct {
-		result1 kubernetes.Action
-	}{result1}
-}
-
-func (fake *FakeActionHandler) NewRollingRestartAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
-	fake.newRollingRestartActionMutex.Lock()
-	ret, specificReturn := fake.newRollingRestartActionReturnsOnCall[len(fake.newRollingRestartActionArgsForCall)]
-	fake.newRollingRestartActionArgsForCall = append(fake.newRollingRestartActionArgsForCall, struct {
-		arg1 kubernetes.ActionConfig
-	}{arg1})
-	fake.recordInvocation("NewRollingRestartAction", []interface{}{arg1})
-	fake.newRollingRestartActionMutex.Unlock()
-	if fake.NewRollingRestartActionStub != nil {
-		return fake.NewRollingRestartActionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.newRollingRestartActionReturns.result1
-}
-
-func (fake *FakeActionHandler) NewRollingRestartActionCallCount() int {
-	fake.newRollingRestartActionMutex.RLock()
-	defer fake.newRollingRestartActionMutex.RUnlock()
-	return len(fake.newRollingRestartActionArgsForCall)
-}
-
-func (fake *FakeActionHandler) NewRollingRestartActionArgsForCall(i int) kubernetes.ActionConfig {
-	fake.newRollingRestartActionMutex.RLock()
-	defer fake.newRollingRestartActionMutex.RUnlock()
-	return fake.newRollingRestartActionArgsForCall[i].arg1
-}
-
-func (fake *FakeActionHandler) NewRollingRestartActionReturns(result1 kubernetes.Action) {
-	fake.NewRollingRestartActionStub = nil
-	fake.newRollingRestartActionReturns = struct {
-		result1 kubernetes.Action
-	}{result1}
-}
-
-func (fake *FakeActionHandler) NewRollingRestartActionReturnsOnCall(i int, result1 kubernetes.Action) {
-	fake.NewRollingRestartActionStub = nil
-	if fake.newRollingRestartActionReturnsOnCall == nil {
-		fake.newRollingRestartActionReturnsOnCall = make(map[int]struct {
-			result1 kubernetes.Action
-		})
-	}
-	fake.newRollingRestartActionReturnsOnCall[i] = struct {
 		result1 kubernetes.Action
 	}{result1}
 }
@@ -177,7 +141,8 @@ func (fake *FakeActionHandler) NewRollbackAction(arg1 kubernetes.ActionConfig) k
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newRollbackActionReturns.result1
+	fakeReturns := fake.newRollbackActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewRollbackActionCallCount() int {
@@ -186,13 +151,22 @@ func (fake *FakeActionHandler) NewRollbackActionCallCount() int {
 	return len(fake.newRollbackActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewRollbackActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newRollbackActionMutex.Lock()
+	defer fake.newRollbackActionMutex.Unlock()
+	fake.NewRollbackActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewRollbackActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newRollbackActionMutex.RLock()
 	defer fake.newRollbackActionMutex.RUnlock()
-	return fake.newRollbackActionArgsForCall[i].arg1
+	argsForCall := fake.newRollbackActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewRollbackActionReturns(result1 kubernetes.Action) {
+	fake.newRollbackActionMutex.Lock()
+	defer fake.newRollbackActionMutex.Unlock()
 	fake.NewRollbackActionStub = nil
 	fake.newRollbackActionReturns = struct {
 		result1 kubernetes.Action
@@ -200,6 +174,8 @@ func (fake *FakeActionHandler) NewRollbackActionReturns(result1 kubernetes.Actio
 }
 
 func (fake *FakeActionHandler) NewRollbackActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newRollbackActionMutex.Lock()
+	defer fake.newRollbackActionMutex.Unlock()
 	fake.NewRollbackActionStub = nil
 	if fake.newRollbackActionReturnsOnCall == nil {
 		fake.newRollbackActionReturnsOnCall = make(map[int]struct {
@@ -207,6 +183,66 @@ func (fake *FakeActionHandler) NewRollbackActionReturnsOnCall(i int, result1 kub
 		})
 	}
 	fake.newRollbackActionReturnsOnCall[i] = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
+func (fake *FakeActionHandler) NewRollingRestartAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
+	fake.newRollingRestartActionMutex.Lock()
+	ret, specificReturn := fake.newRollingRestartActionReturnsOnCall[len(fake.newRollingRestartActionArgsForCall)]
+	fake.newRollingRestartActionArgsForCall = append(fake.newRollingRestartActionArgsForCall, struct {
+		arg1 kubernetes.ActionConfig
+	}{arg1})
+	fake.recordInvocation("NewRollingRestartAction", []interface{}{arg1})
+	fake.newRollingRestartActionMutex.Unlock()
+	if fake.NewRollingRestartActionStub != nil {
+		return fake.NewRollingRestartActionStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.newRollingRestartActionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionCallCount() int {
+	fake.newRollingRestartActionMutex.RLock()
+	defer fake.newRollingRestartActionMutex.RUnlock()
+	return len(fake.newRollingRestartActionArgsForCall)
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newRollingRestartActionMutex.Lock()
+	defer fake.newRollingRestartActionMutex.Unlock()
+	fake.NewRollingRestartActionStub = stub
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionArgsForCall(i int) kubernetes.ActionConfig {
+	fake.newRollingRestartActionMutex.RLock()
+	defer fake.newRollingRestartActionMutex.RUnlock()
+	argsForCall := fake.newRollingRestartActionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionReturns(result1 kubernetes.Action) {
+	fake.newRollingRestartActionMutex.Lock()
+	defer fake.newRollingRestartActionMutex.Unlock()
+	fake.NewRollingRestartActionStub = nil
+	fake.newRollingRestartActionReturns = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newRollingRestartActionMutex.Lock()
+	defer fake.newRollingRestartActionMutex.Unlock()
+	fake.NewRollingRestartActionStub = nil
+	if fake.newRollingRestartActionReturnsOnCall == nil {
+		fake.newRollingRestartActionReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Action
+		})
+	}
+	fake.newRollingRestartActionReturnsOnCall[i] = struct {
 		result1 kubernetes.Action
 	}{result1}
 }
@@ -225,7 +261,8 @@ func (fake *FakeActionHandler) NewRunJobAction(arg1 kubernetes.ActionConfig) kub
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newRunJobActionReturns.result1
+	fakeReturns := fake.newRunJobActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewRunJobActionCallCount() int {
@@ -234,13 +271,22 @@ func (fake *FakeActionHandler) NewRunJobActionCallCount() int {
 	return len(fake.newRunJobActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewRunJobActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newRunJobActionMutex.Lock()
+	defer fake.newRunJobActionMutex.Unlock()
+	fake.NewRunJobActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewRunJobActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newRunJobActionMutex.RLock()
 	defer fake.newRunJobActionMutex.RUnlock()
-	return fake.newRunJobActionArgsForCall[i].arg1
+	argsForCall := fake.newRunJobActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewRunJobActionReturns(result1 kubernetes.Action) {
+	fake.newRunJobActionMutex.Lock()
+	defer fake.newRunJobActionMutex.Unlock()
 	fake.NewRunJobActionStub = nil
 	fake.newRunJobActionReturns = struct {
 		result1 kubernetes.Action
@@ -248,6 +294,8 @@ func (fake *FakeActionHandler) NewRunJobActionReturns(result1 kubernetes.Action)
 }
 
 func (fake *FakeActionHandler) NewRunJobActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newRunJobActionMutex.Lock()
+	defer fake.newRunJobActionMutex.Unlock()
 	fake.NewRunJobActionStub = nil
 	if fake.newRunJobActionReturnsOnCall == nil {
 		fake.newRunJobActionReturnsOnCall = make(map[int]struct {
@@ -273,7 +321,8 @@ func (fake *FakeActionHandler) NewScaleManifestAction(arg1 kubernetes.ActionConf
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newScaleManifestActionReturns.result1
+	fakeReturns := fake.newScaleManifestActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewScaleManifestActionCallCount() int {
@@ -282,13 +331,22 @@ func (fake *FakeActionHandler) NewScaleManifestActionCallCount() int {
 	return len(fake.newScaleManifestActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewScaleManifestActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newScaleManifestActionMutex.Lock()
+	defer fake.newScaleManifestActionMutex.Unlock()
+	fake.NewScaleManifestActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewScaleManifestActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newScaleManifestActionMutex.RLock()
 	defer fake.newScaleManifestActionMutex.RUnlock()
-	return fake.newScaleManifestActionArgsForCall[i].arg1
+	argsForCall := fake.newScaleManifestActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewScaleManifestActionReturns(result1 kubernetes.Action) {
+	fake.newScaleManifestActionMutex.Lock()
+	defer fake.newScaleManifestActionMutex.Unlock()
 	fake.NewScaleManifestActionStub = nil
 	fake.newScaleManifestActionReturns = struct {
 		result1 kubernetes.Action
@@ -296,6 +354,8 @@ func (fake *FakeActionHandler) NewScaleManifestActionReturns(result1 kubernetes.
 }
 
 func (fake *FakeActionHandler) NewScaleManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newScaleManifestActionMutex.Lock()
+	defer fake.newScaleManifestActionMutex.Unlock()
 	fake.NewScaleManifestActionStub = nil
 	if fake.newScaleManifestActionReturnsOnCall == nil {
 		fake.newScaleManifestActionReturnsOnCall = make(map[int]struct {
@@ -312,10 +372,10 @@ func (fake *FakeActionHandler) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.newDeployManifestActionMutex.RLock()
 	defer fake.newDeployManifestActionMutex.RUnlock()
-	fake.newRollingRestartActionMutex.RLock()
-	defer fake.newRollingRestartActionMutex.RUnlock()
 	fake.newRollbackActionMutex.RLock()
 	defer fake.newRollbackActionMutex.RUnlock()
+	fake.newRollingRestartActionMutex.RLock()
+	defer fake.newRollingRestartActionMutex.RUnlock()
 	fake.newRunJobActionMutex.RLock()
 	defer fake.newRunJobActionMutex.RUnlock()
 	fake.newScaleManifestActionMutex.RLock()

--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -375,49 +375,57 @@ const payloadRequestKubernetesOpsBadManifest = `[
 ]`
 
 const payloadCredentials = `[
-            {
-              "accountType": "provider1",
-              "cacheThreads": 0,
-              "challengeDestructiveActions": false,
-              "cloudProvider": "kubernetes",
-              "dockerRegistries": null,
-              "enabled": false,
-              "environment": "provider1",
-              "name": "provider1",
-              "namespaces": null,
-              "permissions": {
-                "READ": null,
-                "WRITE": null
+              {
+                "accountType": "provider1",
+                "cacheThreads": 0,
+                "challengeDestructiveActions": false,
+                "cloudProvider": "kubernetes",
+                "dockerRegistries": null,
+                "enabled": false,
+                "environment": "provider1",
+                "name": "provider1",
+                "namespaces": null,
+                "permissions": {
+                  "READ": [
+                    "gg_test"
+                  ],
+                  "WRITE": [
+                    "gg_test"
+                  ]
+                },
+                "primaryAccount": false,
+                "providerVersion": "v2",
+                "requiredGroupMembership": [],
+                "skin": "v2",
+                "spinnakerKindMap": null,
+                "type": "kubernetes"
               },
-              "primaryAccount": false,
-              "providerVersion": "v2",
-              "requiredGroupMembership": [],
-              "skin": "v2",
-              "spinnakerKindMap": null,
-              "type": "kubernetes"
-            },
-            {
-              "accountType": "provider2",
-              "cacheThreads": 0,
-              "challengeDestructiveActions": false,
-              "cloudProvider": "kubernetes",
-              "dockerRegistries": null,
-              "enabled": false,
-              "environment": "provider2",
-              "name": "provider2",
-              "namespaces": null,
-              "permissions": {
-                "READ": null,
-                "WRITE": null
-              },
-              "primaryAccount": false,
-              "providerVersion": "v2",
-              "requiredGroupMembership": [],
-              "skin": "v2",
-              "spinnakerKindMap": null,
-              "type": "kubernetes"
-            }
-          ]`
+              {
+                "accountType": "provider2",
+                "cacheThreads": 0,
+                "challengeDestructiveActions": false,
+                "cloudProvider": "kubernetes",
+                "dockerRegistries": null,
+                "enabled": false,
+                "environment": "provider2",
+                "name": "provider2",
+                "namespaces": null,
+                "permissions": {
+                  "READ": [
+                    "gg_test2"
+                  ],
+                  "WRITE": [
+                    "gg_test2"
+                  ]
+                },
+                "primaryAccount": false,
+                "providerVersion": "v2",
+                "requiredGroupMembership": [],
+                "skin": "v2",
+                "spinnakerKindMap": null,
+                "type": "kubernetes"
+              }
+            ]`
 
 const payloadArtifactCredentials = `[
             {
@@ -542,8 +550,12 @@ const payloadCredentialsExpandTrue = `[
                   "namespace2"
                 ],
                 "permissions": {
-                  "READ": null,
-                  "WRITE": null
+                  "READ": [
+                    "gg_test"
+                  ],
+                  "WRITE": [
+                    "gg_test"
+                  ]
                 },
                 "primaryAccount": false,
                 "providerVersion": "v2",
@@ -599,8 +611,12 @@ const payloadCredentialsExpandTrue = `[
                   "namespace2"
                 ],
                 "permissions": {
-                  "READ": null,
-                  "WRITE": null
+                  "READ": [
+                    "gg_test2"
+                  ],
+                  "WRITE": [
+                    "gg_test2"
+                  ]
                 },
                 "primaryAccount": false,
                 "providerVersion": "v2",
@@ -656,8 +672,12 @@ const payloadCredentialsExpandTrueNoNamespaces = `[
                 "name": "provider1",
                 "namespaces": null,
                 "permissions": {
-                  "READ": null,
-                  "WRITE": null
+                  "READ": [
+                    "gg_test"
+                  ],
+                  "WRITE": [
+                    "gg_test"
+                  ]
                 },
                 "primaryAccount": false,
                 "providerVersion": "v2",
@@ -710,8 +730,12 @@ const payloadCredentialsExpandTrueNoNamespaces = `[
                 "name": "provider2",
                 "namespaces": null,
                 "permissions": {
-                  "READ": null,
-                  "WRITE": null
+                  "READ": [
+                    "gg_test2"
+                  ],
+                  "WRITE": [
+                    "gg_test2"
+                  ]
                 },
                 "primaryAccount": false,
                 "providerVersion": "v2",

--- a/pkg/kubernetes/kubernetesfakes/fake_client.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_client.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/billiford/go-clouddriver/pkg/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -53,11 +53,11 @@ type FakeClient struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	ListStub        func(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListStub        func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)
 	listMutex       sync.RWMutex
 	listArgsForCall []struct {
 		arg1 schema.GroupVersionResource
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}
 	listReturns struct {
 		result1 *unstructured.UnstructuredList
@@ -85,7 +85,8 @@ func (fake *FakeClient) Apply(arg1 *unstructured.Unstructured) (kubernetes.Metad
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.applyReturns.result1, fake.applyReturns.result2
+	fakeReturns := fake.applyReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ApplyCallCount() int {
@@ -94,13 +95,22 @@ func (fake *FakeClient) ApplyCallCount() int {
 	return len(fake.applyArgsForCall)
 }
 
+func (fake *FakeClient) ApplyCalls(stub func(*unstructured.Unstructured) (kubernetes.Metadata, error)) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
+	fake.ApplyStub = stub
+}
+
 func (fake *FakeClient) ApplyArgsForCall(i int) *unstructured.Unstructured {
 	fake.applyMutex.RLock()
 	defer fake.applyMutex.RUnlock()
-	return fake.applyArgsForCall[i].arg1
+	argsForCall := fake.applyArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	fake.applyReturns = struct {
 		result1 kubernetes.Metadata
@@ -109,6 +119,8 @@ func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error)
 }
 
 func (fake *FakeClient) ApplyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	if fake.applyReturnsOnCall == nil {
 		fake.applyReturnsOnCall = make(map[int]struct {
@@ -137,7 +149,8 @@ func (fake *FakeClient) ApplyWithNamespaceOverride(arg1 *unstructured.Unstructur
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.applyWithNamespaceOverrideReturns.result1, fake.applyWithNamespaceOverrideReturns.result2
+	fakeReturns := fake.applyWithNamespaceOverrideReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
@@ -146,13 +159,22 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
 	return len(fake.applyWithNamespaceOverrideArgsForCall)
 }
 
+func (fake *FakeClient) ApplyWithNamespaceOverrideCalls(stub func(*unstructured.Unstructured, string) (kubernetes.Metadata, error)) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
+	fake.ApplyWithNamespaceOverrideStub = stub
+}
+
 func (fake *FakeClient) ApplyWithNamespaceOverrideArgsForCall(i int) (*unstructured.Unstructured, string) {
 	fake.applyWithNamespaceOverrideMutex.RLock()
 	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
-	return fake.applyWithNamespaceOverrideArgsForCall[i].arg1, fake.applyWithNamespaceOverrideArgsForCall[i].arg2
+	argsForCall := fake.applyWithNamespaceOverrideArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Metadata, result2 error) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	fake.applyWithNamespaceOverrideReturns = struct {
 		result1 kubernetes.Metadata
@@ -161,6 +183,8 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Met
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	if fake.applyWithNamespaceOverrideReturnsOnCall == nil {
 		fake.applyWithNamespaceOverrideReturnsOnCall = make(map[int]struct {
@@ -190,7 +214,8 @@ func (fake *FakeClient) Get(arg1 string, arg2 string, arg3 string) (*unstructure
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getReturns.result1, fake.getReturns.result2
+	fakeReturns := fake.getReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GetCallCount() int {
@@ -199,13 +224,22 @@ func (fake *FakeClient) GetCallCount() int {
 	return len(fake.getArgsForCall)
 }
 
+func (fake *FakeClient) GetCalls(stub func(string, string, string) (*unstructured.Unstructured, error)) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = stub
+}
+
 func (fake *FakeClient) GetArgsForCall(i int) (string, string, string) {
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
-	return fake.getArgsForCall[i].arg1, fake.getArgsForCall[i].arg2, fake.getArgsForCall[i].arg3
+	argsForCall := fake.getArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	fake.getReturns = struct {
 		result1 *unstructured.Unstructured
@@ -214,6 +248,8 @@ func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 e
 }
 
 func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	if fake.getReturnsOnCall == nil {
 		fake.getReturnsOnCall = make(map[int]struct {
@@ -227,12 +263,12 @@ func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructur
 	}{result1, result2}
 }
 
-func (fake *FakeClient) List(arg1 schema.GroupVersionResource, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (fake *FakeClient) List(arg1 schema.GroupVersionResource, arg2 v1.ListOptions) (*unstructured.UnstructuredList, error) {
 	fake.listMutex.Lock()
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		arg1 schema.GroupVersionResource
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}{arg1, arg2})
 	fake.recordInvocation("List", []interface{}{arg1, arg2})
 	fake.listMutex.Unlock()
@@ -242,7 +278,8 @@ func (fake *FakeClient) List(arg1 schema.GroupVersionResource, arg2 metav1.ListO
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listReturns.result1, fake.listReturns.result2
+	fakeReturns := fake.listReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListCallCount() int {
@@ -251,13 +288,22 @@ func (fake *FakeClient) ListCallCount() int {
 	return len(fake.listArgsForCall)
 }
 
-func (fake *FakeClient) ListArgsForCall(i int) (schema.GroupVersionResource, metav1.ListOptions) {
+func (fake *FakeClient) ListCalls(stub func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
+	fake.listMutex.Lock()
+	defer fake.listMutex.Unlock()
+	fake.ListStub = stub
+}
+
+func (fake *FakeClient) ListArgsForCall(i int) (schema.GroupVersionResource, v1.ListOptions) {
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
-	return fake.listArgsForCall[i].arg1, fake.listArgsForCall[i].arg2
+	argsForCall := fake.listArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ListReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listMutex.Lock()
+	defer fake.listMutex.Unlock()
 	fake.ListStub = nil
 	fake.listReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -266,6 +312,8 @@ func (fake *FakeClient) ListReturns(result1 *unstructured.UnstructuredList, resu
 }
 
 func (fake *FakeClient) ListReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listMutex.Lock()
+	defer fake.listMutex.Unlock()
 	fake.ListStub = nil
 	if fake.listReturnsOnCall == nil {
 		fake.listReturnsOnCall = make(map[int]struct {

--- a/pkg/kubernetes/kubernetesfakes/fake_controller.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_controller.go
@@ -10,6 +10,30 @@ import (
 )
 
 type FakeController struct {
+	AddSpinnakerAnnotationsStub        func(*unstructured.Unstructured, string) error
+	addSpinnakerAnnotationsMutex       sync.RWMutex
+	addSpinnakerAnnotationsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}
+	addSpinnakerAnnotationsReturns struct {
+		result1 error
+	}
+	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	AddSpinnakerLabelsStub        func(*unstructured.Unstructured, string) error
+	addSpinnakerLabelsMutex       sync.RWMutex
+	addSpinnakerLabelsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}
+	addSpinnakerLabelsReturns struct {
+		result1 error
+	}
+	addSpinnakerLabelsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	NewClientStub        func(*rest.Config) (kubernetes.Client, error)
 	newClientMutex       sync.RWMutex
 	newClientArgsForCall []struct {
@@ -36,32 +60,130 @@ type FakeController struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	AddSpinnakerAnnotationsStub        func(u *unstructured.Unstructured, application string) error
-	addSpinnakerAnnotationsMutex       sync.RWMutex
-	addSpinnakerAnnotationsArgsForCall []struct {
-		u           *unstructured.Unstructured
-		application string
-	}
-	addSpinnakerAnnotationsReturns struct {
-		result1 error
-	}
-	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	AddSpinnakerLabelsStub        func(u *unstructured.Unstructured, application string) error
-	addSpinnakerLabelsMutex       sync.RWMutex
-	addSpinnakerLabelsArgsForCall []struct {
-		u           *unstructured.Unstructured
-		application string
-	}
-	addSpinnakerLabelsReturns struct {
-		result1 error
-	}
-	addSpinnakerLabelsReturnsOnCall map[int]struct {
-		result1 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeController) AddSpinnakerAnnotations(arg1 *unstructured.Unstructured, arg2 string) error {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
+	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{arg1, arg2})
+	fake.addSpinnakerAnnotationsMutex.Unlock()
+	if fake.AddSpinnakerAnnotationsStub != nil {
+		return fake.AddSpinnakerAnnotationsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerAnnotationsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	return len(fake.addSpinnakerAnnotationsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsCalls(stub func(*unstructured.Unstructured, string) error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerAnnotationsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = nil
+	fake.addSpinnakerAnnotationsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = nil
+	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
+		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabels(arg1 *unstructured.Unstructured, arg2 string) error {
+	fake.addSpinnakerLabelsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
+	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerLabels", []interface{}{arg1, arg2})
+	fake.addSpinnakerLabelsMutex.Unlock()
+	if fake.AddSpinnakerLabelsStub != nil {
+		return fake.AddSpinnakerLabelsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerLabelsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	return len(fake.addSpinnakerLabelsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerLabelsCalls(stub func(*unstructured.Unstructured, string) error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerLabelsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = nil
+	fake.addSpinnakerLabelsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = nil
+	if fake.addSpinnakerLabelsReturnsOnCall == nil {
+		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, error) {
@@ -78,7 +200,8 @@ func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, err
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.newClientReturns.result1, fake.newClientReturns.result2
+	fakeReturns := fake.newClientReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeController) NewClientCallCount() int {
@@ -87,13 +210,22 @@ func (fake *FakeController) NewClientCallCount() int {
 	return len(fake.newClientArgsForCall)
 }
 
+func (fake *FakeController) NewClientCalls(stub func(*rest.Config) (kubernetes.Client, error)) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
+	fake.NewClientStub = stub
+}
+
 func (fake *FakeController) NewClientArgsForCall(i int) *rest.Config {
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
-	return fake.newClientArgsForCall[i].arg1
+	argsForCall := fake.newClientArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 error) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	fake.newClientReturns = struct {
 		result1 kubernetes.Client
@@ -102,6 +234,8 @@ func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 
 }
 
 func (fake *FakeController) NewClientReturnsOnCall(i int, result1 kubernetes.Client, result2 error) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	if fake.newClientReturnsOnCall == nil {
 		fake.newClientReturnsOnCall = make(map[int]struct {
@@ -129,7 +263,8 @@ func (fake *FakeController) ToUnstructured(arg1 map[string]interface{}) (*unstru
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.toUnstructuredReturns.result1, fake.toUnstructuredReturns.result2
+	fakeReturns := fake.toUnstructuredReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeController) ToUnstructuredCallCount() int {
@@ -138,13 +273,22 @@ func (fake *FakeController) ToUnstructuredCallCount() int {
 	return len(fake.toUnstructuredArgsForCall)
 }
 
+func (fake *FakeController) ToUnstructuredCalls(stub func(map[string]interface{}) (*unstructured.Unstructured, error)) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
+	fake.ToUnstructuredStub = stub
+}
+
 func (fake *FakeController) ToUnstructuredArgsForCall(i int) map[string]interface{} {
 	fake.toUnstructuredMutex.RLock()
 	defer fake.toUnstructuredMutex.RUnlock()
-	return fake.toUnstructuredArgsForCall[i].arg1
+	argsForCall := fake.toUnstructuredArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstructured, result2 error) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
 	fake.ToUnstructuredStub = nil
 	fake.toUnstructuredReturns = struct {
 		result1 *unstructured.Unstructured
@@ -153,6 +297,8 @@ func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstruct
 }
 
 func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
 	fake.ToUnstructuredStub = nil
 	if fake.toUnstructuredReturnsOnCall == nil {
 		fake.toUnstructuredReturnsOnCall = make(map[int]struct {
@@ -166,115 +312,17 @@ func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstruct
 	}{result1, result2}
 }
 
-func (fake *FakeController) AddSpinnakerAnnotations(u *unstructured.Unstructured, application string) error {
-	fake.addSpinnakerAnnotationsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
-	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
-		u           *unstructured.Unstructured
-		application string
-	}{u, application})
-	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{u, application})
-	fake.addSpinnakerAnnotationsMutex.Unlock()
-	if fake.AddSpinnakerAnnotationsStub != nil {
-		return fake.AddSpinnakerAnnotationsStub(u, application)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.addSpinnakerAnnotationsReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	return len(fake.addSpinnakerAnnotationsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	return fake.addSpinnakerAnnotationsArgsForCall[i].u, fake.addSpinnakerAnnotationsArgsForCall[i].application
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
-	fake.AddSpinnakerAnnotationsStub = nil
-	fake.addSpinnakerAnnotationsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerAnnotationsStub = nil
-	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
-		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabels(u *unstructured.Unstructured, application string) error {
-	fake.addSpinnakerLabelsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
-	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
-		u           *unstructured.Unstructured
-		application string
-	}{u, application})
-	fake.recordInvocation("AddSpinnakerLabels", []interface{}{u, application})
-	fake.addSpinnakerLabelsMutex.Unlock()
-	if fake.AddSpinnakerLabelsStub != nil {
-		return fake.AddSpinnakerLabelsStub(u, application)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.addSpinnakerLabelsReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	return len(fake.addSpinnakerLabelsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	return fake.addSpinnakerLabelsArgsForCall[i].u, fake.addSpinnakerLabelsArgsForCall[i].application
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
-	fake.AddSpinnakerLabelsStub = nil
-	fake.addSpinnakerLabelsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerLabelsStub = nil
-	if fake.addSpinnakerLabelsReturnsOnCall == nil {
-		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
 	fake.toUnstructuredMutex.RLock()
 	defer fake.toUnstructuredMutex.RUnlock()
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/sql/sqlfakes/fake_client.go
+++ b/pkg/sql/sqlfakes/fake_client.go
@@ -7,23 +7,9 @@ import (
 	clouddriver "github.com/billiford/go-clouddriver/pkg"
 	"github.com/billiford/go-clouddriver/pkg/kubernetes"
 	"github.com/billiford/go-clouddriver/pkg/sql"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 type FakeClient struct {
-	GetKubernetesProviderStub        func(string) (kubernetes.Provider, error)
-	getKubernetesProviderMutex       sync.RWMutex
-	getKubernetesProviderArgsForCall []struct {
-		arg1 string
-	}
-	getKubernetesProviderReturns struct {
-		result1 kubernetes.Provider
-		result2 error
-	}
-	getKubernetesProviderReturnsOnCall map[int]struct {
-		result1 kubernetes.Provider
-		result2 error
-	}
 	CreateKubernetesProviderStub        func(kubernetes.Provider) error
 	createKubernetesProviderMutex       sync.RWMutex
 	createKubernetesProviderArgsForCall []struct {
@@ -68,14 +54,53 @@ type FakeClient struct {
 	createWritePermissionReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GetKubernetesProviderStub        func(string) (kubernetes.Provider, error)
+	getKubernetesProviderMutex       sync.RWMutex
+	getKubernetesProviderArgsForCall []struct {
+		arg1 string
+	}
+	getKubernetesProviderReturns struct {
+		result1 kubernetes.Provider
+		result2 error
+	}
+	getKubernetesProviderReturnsOnCall map[int]struct {
+		result1 kubernetes.Provider
+		result2 error
+	}
+	ListKubernetesAccountsBySpinnakerAppStub        func(string) ([]string, error)
+	listKubernetesAccountsBySpinnakerAppMutex       sync.RWMutex
+	listKubernetesAccountsBySpinnakerAppArgsForCall []struct {
+		arg1 string
+	}
+	listKubernetesAccountsBySpinnakerAppReturns struct {
+		result1 []string
+		result2 error
+	}
+	listKubernetesAccountsBySpinnakerAppReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
 	ListKubernetesProvidersStub        func() ([]kubernetes.Provider, error)
 	listKubernetesProvidersMutex       sync.RWMutex
-	listKubernetesProvidersArgsForCall []struct{}
-	listKubernetesProvidersReturns     struct {
+	listKubernetesProvidersArgsForCall []struct {
+	}
+	listKubernetesProvidersReturns struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
 	listKubernetesProvidersReturnsOnCall map[int]struct {
+		result1 []kubernetes.Provider
+		result2 error
+	}
+	ListKubernetesProvidersAndPermissionsStub        func() ([]kubernetes.Provider, error)
+	listKubernetesProvidersAndPermissionsMutex       sync.RWMutex
+	listKubernetesProvidersAndPermissionsArgsForCall []struct {
+	}
+	listKubernetesProvidersAndPermissionsReturns struct {
+		result1 []kubernetes.Provider
+		result2 error
+	}
+	listKubernetesProvidersAndPermissionsReturnsOnCall map[int]struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
@@ -103,19 +128,6 @@ type FakeClient struct {
 	}
 	listKubernetesResourcesByTaskIDReturnsOnCall map[int]struct {
 		result1 []kubernetes.Resource
-		result2 error
-	}
-	ListKubernetesAccountsBySpinnakerAppStub        func(string) ([]string, error)
-	listKubernetesAccountsBySpinnakerAppMutex       sync.RWMutex
-	listKubernetesAccountsBySpinnakerAppArgsForCall []struct {
-		arg1 string
-	}
-	listKubernetesAccountsBySpinnakerAppReturns struct {
-		result1 []string
-		result2 error
-	}
-	listKubernetesAccountsBySpinnakerAppReturnsOnCall map[int]struct {
-		result1 []string
 		result2 error
 	}
 	ListReadGroupsByAccountNameStub        func(string) ([]string, error)
@@ -148,57 +160,6 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) GetKubernetesProvider(arg1 string) (kubernetes.Provider, error) {
-	fake.getKubernetesProviderMutex.Lock()
-	ret, specificReturn := fake.getKubernetesProviderReturnsOnCall[len(fake.getKubernetesProviderArgsForCall)]
-	fake.getKubernetesProviderArgsForCall = append(fake.getKubernetesProviderArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("GetKubernetesProvider", []interface{}{arg1})
-	fake.getKubernetesProviderMutex.Unlock()
-	if fake.GetKubernetesProviderStub != nil {
-		return fake.GetKubernetesProviderStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.getKubernetesProviderReturns.result1, fake.getKubernetesProviderReturns.result2
-}
-
-func (fake *FakeClient) GetKubernetesProviderCallCount() int {
-	fake.getKubernetesProviderMutex.RLock()
-	defer fake.getKubernetesProviderMutex.RUnlock()
-	return len(fake.getKubernetesProviderArgsForCall)
-}
-
-func (fake *FakeClient) GetKubernetesProviderArgsForCall(i int) string {
-	fake.getKubernetesProviderMutex.RLock()
-	defer fake.getKubernetesProviderMutex.RUnlock()
-	return fake.getKubernetesProviderArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider, result2 error) {
-	fake.GetKubernetesProviderStub = nil
-	fake.getKubernetesProviderReturns = struct {
-		result1 kubernetes.Provider
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetKubernetesProviderReturnsOnCall(i int, result1 kubernetes.Provider, result2 error) {
-	fake.GetKubernetesProviderStub = nil
-	if fake.getKubernetesProviderReturnsOnCall == nil {
-		fake.getKubernetesProviderReturnsOnCall = make(map[int]struct {
-			result1 kubernetes.Provider
-			result2 error
-		})
-	}
-	fake.getKubernetesProviderReturnsOnCall[i] = struct {
-		result1 kubernetes.Provider
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeClient) CreateKubernetesProvider(arg1 kubernetes.Provider) error {
 	fake.createKubernetesProviderMutex.Lock()
 	ret, specificReturn := fake.createKubernetesProviderReturnsOnCall[len(fake.createKubernetesProviderArgsForCall)]
@@ -213,7 +174,8 @@ func (fake *FakeClient) CreateKubernetesProvider(arg1 kubernetes.Provider) error
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createKubernetesProviderReturns.result1
+	fakeReturns := fake.createKubernetesProviderReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
@@ -222,13 +184,22 @@ func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
 	return len(fake.createKubernetesProviderArgsForCall)
 }
 
+func (fake *FakeClient) CreateKubernetesProviderCalls(stub func(kubernetes.Provider) error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
+	fake.CreateKubernetesProviderStub = stub
+}
+
 func (fake *FakeClient) CreateKubernetesProviderArgsForCall(i int) kubernetes.Provider {
 	fake.createKubernetesProviderMutex.RLock()
 	defer fake.createKubernetesProviderMutex.RUnlock()
-	return fake.createKubernetesProviderArgsForCall[i].arg1
+	argsForCall := fake.createKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	fake.createKubernetesProviderReturns = struct {
 		result1 error
@@ -236,6 +207,8 @@ func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturnsOnCall(i int, result1 error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	if fake.createKubernetesProviderReturnsOnCall == nil {
 		fake.createKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -261,7 +234,8 @@ func (fake *FakeClient) CreateKubernetesResource(arg1 kubernetes.Resource) error
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createKubernetesResourceReturns.result1
+	fakeReturns := fake.createKubernetesResourceReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
@@ -270,13 +244,22 @@ func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
 	return len(fake.createKubernetesResourceArgsForCall)
 }
 
+func (fake *FakeClient) CreateKubernetesResourceCalls(stub func(kubernetes.Resource) error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
+	fake.CreateKubernetesResourceStub = stub
+}
+
 func (fake *FakeClient) CreateKubernetesResourceArgsForCall(i int) kubernetes.Resource {
 	fake.createKubernetesResourceMutex.RLock()
 	defer fake.createKubernetesResourceMutex.RUnlock()
-	return fake.createKubernetesResourceArgsForCall[i].arg1
+	argsForCall := fake.createKubernetesResourceArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	fake.createKubernetesResourceReturns = struct {
 		result1 error
@@ -284,6 +267,8 @@ func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturnsOnCall(i int, result1 error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	if fake.createKubernetesResourceReturnsOnCall == nil {
 		fake.createKubernetesResourceReturnsOnCall = make(map[int]struct {
@@ -309,7 +294,8 @@ func (fake *FakeClient) CreateReadPermission(arg1 clouddriver.ReadPermission) er
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createReadPermissionReturns.result1
+	fakeReturns := fake.createReadPermissionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateReadPermissionCallCount() int {
@@ -318,13 +304,22 @@ func (fake *FakeClient) CreateReadPermissionCallCount() int {
 	return len(fake.createReadPermissionArgsForCall)
 }
 
+func (fake *FakeClient) CreateReadPermissionCalls(stub func(clouddriver.ReadPermission) error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
+	fake.CreateReadPermissionStub = stub
+}
+
 func (fake *FakeClient) CreateReadPermissionArgsForCall(i int) clouddriver.ReadPermission {
 	fake.createReadPermissionMutex.RLock()
 	defer fake.createReadPermissionMutex.RUnlock()
-	return fake.createReadPermissionArgsForCall[i].arg1
+	argsForCall := fake.createReadPermissionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	fake.createReadPermissionReturns = struct {
 		result1 error
@@ -332,6 +327,8 @@ func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateReadPermissionReturnsOnCall(i int, result1 error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	if fake.createReadPermissionReturnsOnCall == nil {
 		fake.createReadPermissionReturnsOnCall = make(map[int]struct {
@@ -357,7 +354,8 @@ func (fake *FakeClient) CreateWritePermission(arg1 clouddriver.WritePermission) 
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createWritePermissionReturns.result1
+	fakeReturns := fake.createWritePermissionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateWritePermissionCallCount() int {
@@ -366,13 +364,22 @@ func (fake *FakeClient) CreateWritePermissionCallCount() int {
 	return len(fake.createWritePermissionArgsForCall)
 }
 
+func (fake *FakeClient) CreateWritePermissionCalls(stub func(clouddriver.WritePermission) error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
+	fake.CreateWritePermissionStub = stub
+}
+
 func (fake *FakeClient) CreateWritePermissionArgsForCall(i int) clouddriver.WritePermission {
 	fake.createWritePermissionMutex.RLock()
 	defer fake.createWritePermissionMutex.RUnlock()
-	return fake.createWritePermissionArgsForCall[i].arg1
+	argsForCall := fake.createWritePermissionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	fake.createWritePermissionReturns = struct {
 		result1 error
@@ -380,6 +387,8 @@ func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	if fake.createWritePermissionReturnsOnCall == nil {
 		fake.createWritePermissionReturnsOnCall = make(map[int]struct {
@@ -391,10 +400,137 @@ func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error)
 	}{result1}
 }
 
+func (fake *FakeClient) GetKubernetesProvider(arg1 string) (kubernetes.Provider, error) {
+	fake.getKubernetesProviderMutex.Lock()
+	ret, specificReturn := fake.getKubernetesProviderReturnsOnCall[len(fake.getKubernetesProviderArgsForCall)]
+	fake.getKubernetesProviderArgsForCall = append(fake.getKubernetesProviderArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetKubernetesProvider", []interface{}{arg1})
+	fake.getKubernetesProviderMutex.Unlock()
+	if fake.GetKubernetesProviderStub != nil {
+		return fake.GetKubernetesProviderStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getKubernetesProviderReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetKubernetesProviderCallCount() int {
+	fake.getKubernetesProviderMutex.RLock()
+	defer fake.getKubernetesProviderMutex.RUnlock()
+	return len(fake.getKubernetesProviderArgsForCall)
+}
+
+func (fake *FakeClient) GetKubernetesProviderCalls(stub func(string) (kubernetes.Provider, error)) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
+	fake.GetKubernetesProviderStub = stub
+}
+
+func (fake *FakeClient) GetKubernetesProviderArgsForCall(i int) string {
+	fake.getKubernetesProviderMutex.RLock()
+	defer fake.getKubernetesProviderMutex.RUnlock()
+	argsForCall := fake.getKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
+	fake.GetKubernetesProviderStub = nil
+	fake.getKubernetesProviderReturns = struct {
+		result1 kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetKubernetesProviderReturnsOnCall(i int, result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
+	fake.GetKubernetesProviderStub = nil
+	if fake.getKubernetesProviderReturnsOnCall == nil {
+		fake.getKubernetesProviderReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Provider
+			result2 error
+		})
+	}
+	fake.getKubernetesProviderReturnsOnCall[i] = struct {
+		result1 kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]string, error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	ret, specificReturn := fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)]
+	fake.listKubernetesAccountsBySpinnakerAppArgsForCall = append(fake.listKubernetesAccountsBySpinnakerAppArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("ListKubernetesAccountsBySpinnakerApp", []interface{}{arg1})
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
+	if fake.ListKubernetesAccountsBySpinnakerAppStub != nil {
+		return fake.ListKubernetesAccountsBySpinnakerAppStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listKubernetesAccountsBySpinnakerAppReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
+	return len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCalls(stub func(string) ([]string, error)) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
+	fake.ListKubernetesAccountsBySpinnakerAppStub = stub
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppArgsForCall(i int) string {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
+	argsForCall := fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []string, result2 error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
+	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
+	fake.listKubernetesAccountsBySpinnakerAppReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
+	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
+	if fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall == nil {
+		fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error) {
 	fake.listKubernetesProvidersMutex.Lock()
 	ret, specificReturn := fake.listKubernetesProvidersReturnsOnCall[len(fake.listKubernetesProvidersArgsForCall)]
-	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct{}{})
+	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct {
+	}{})
 	fake.recordInvocation("ListKubernetesProviders", []interface{}{})
 	fake.listKubernetesProvidersMutex.Unlock()
 	if fake.ListKubernetesProvidersStub != nil {
@@ -403,7 +539,8 @@ func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error)
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesProvidersReturns.result1, fake.listKubernetesProvidersReturns.result2
+	fakeReturns := fake.listKubernetesProvidersReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
@@ -412,7 +549,15 @@ func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
 	return len(fake.listKubernetesProvidersArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesProvidersCalls(stub func() ([]kubernetes.Provider, error)) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
+	fake.ListKubernetesProvidersStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	fake.listKubernetesProvidersReturns = struct {
 		result1 []kubernetes.Provider
@@ -421,6 +566,8 @@ func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Prov
 }
 
 func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	if fake.listKubernetesProvidersReturnsOnCall == nil {
 		fake.listKubernetesProvidersReturnsOnCall = make(map[int]struct {
@@ -429,6 +576,61 @@ func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []ku
 		})
 	}
 	fake.listKubernetesProvidersReturnsOnCall[i] = struct {
+		result1 []kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesProvidersAndPermissions() ([]kubernetes.Provider, error) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	ret, specificReturn := fake.listKubernetesProvidersAndPermissionsReturnsOnCall[len(fake.listKubernetesProvidersAndPermissionsArgsForCall)]
+	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListKubernetesProvidersAndPermissions", []interface{}{})
+	fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
+	if fake.ListKubernetesProvidersAndPermissionsStub != nil {
+		return fake.ListKubernetesProvidersAndPermissionsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listKubernetesProvidersAndPermissionsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCallCount() int {
+	fake.listKubernetesProvidersAndPermissionsMutex.RLock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.RUnlock()
+	return len(fake.listKubernetesProvidersAndPermissionsArgsForCall)
+}
+
+func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCalls(stub func() ([]kubernetes.Provider, error)) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
+	fake.ListKubernetesProvidersAndPermissionsStub = stub
+}
+
+func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturns(result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
+	fake.ListKubernetesProvidersAndPermissionsStub = nil
+	fake.listKubernetesProvidersAndPermissionsReturns = struct {
+		result1 []kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
+	fake.ListKubernetesProvidersAndPermissionsStub = nil
+	if fake.listKubernetesProvidersAndPermissionsReturnsOnCall == nil {
+		fake.listKubernetesProvidersAndPermissionsReturnsOnCall = make(map[int]struct {
+			result1 []kubernetes.Provider
+			result2 error
+		})
+	}
+	fake.listKubernetesProvidersAndPermissionsReturnsOnCall[i] = struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}{result1, result2}
@@ -448,7 +650,8 @@ func (fake *FakeClient) ListKubernetesResourcesByFields(arg1 ...string) ([]kuber
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesResourcesByFieldsReturns.result1, fake.listKubernetesResourcesByFieldsReturns.result2
+	fakeReturns := fake.listKubernetesResourcesByFieldsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
@@ -457,13 +660,22 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
 	return len(fake.listKubernetesResourcesByFieldsArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesResourcesByFieldsCalls(stub func(...string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
+	fake.ListKubernetesResourcesByFieldsStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesResourcesByFieldsArgsForCall(i int) []string {
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
-	return fake.listKubernetesResourcesByFieldsArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesResourcesByFieldsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	fake.listKubernetesResourcesByFieldsReturns = struct {
 		result1 []kubernetes.Resource
@@ -472,6 +684,8 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	if fake.listKubernetesResourcesByFieldsReturnsOnCall == nil {
 		fake.listKubernetesResourcesByFieldsReturnsOnCall = make(map[int]struct {
@@ -499,7 +713,8 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskID(arg1 string) ([]kubernet
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesResourcesByTaskIDReturns.result1, fake.listKubernetesResourcesByTaskIDReturns.result2
+	fakeReturns := fake.listKubernetesResourcesByTaskIDReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
@@ -508,13 +723,22 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
 	return len(fake.listKubernetesResourcesByTaskIDArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesResourcesByTaskIDCalls(stub func(string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
+	fake.ListKubernetesResourcesByTaskIDStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDArgsForCall(i int) string {
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	return fake.listKubernetesResourcesByTaskIDArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesResourcesByTaskIDArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	fake.listKubernetesResourcesByTaskIDReturns = struct {
 		result1 []kubernetes.Resource
@@ -523,6 +747,8 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	if fake.listKubernetesResourcesByTaskIDReturnsOnCall == nil {
 		fake.listKubernetesResourcesByTaskIDReturnsOnCall = make(map[int]struct {
@@ -532,57 +758,6 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, resu
 	}
 	fake.listKubernetesResourcesByTaskIDReturnsOnCall[i] = struct {
 		result1 []kubernetes.Resource
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]string, error) {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
-	ret, specificReturn := fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)]
-	fake.listKubernetesAccountsBySpinnakerAppArgsForCall = append(fake.listKubernetesAccountsBySpinnakerAppArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("ListKubernetesAccountsBySpinnakerApp", []interface{}{arg1})
-	fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
-	if fake.ListKubernetesAccountsBySpinnakerAppStub != nil {
-		return fake.ListKubernetesAccountsBySpinnakerAppStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.listKubernetesAccountsBySpinnakerAppReturns.result1, fake.listKubernetesAccountsBySpinnakerAppReturns.result2
-}
-
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
-	return len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)
-}
-
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppArgsForCall(i int) string {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
-	return fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []string, result2 error) {
-	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
-	fake.listKubernetesAccountsBySpinnakerAppReturns = struct {
-		result1 []string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
-	if fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall == nil {
-		fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall = make(map[int]struct {
-			result1 []string
-			result2 error
-		})
-	}
-	fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[i] = struct {
-		result1 []string
 		result2 error
 	}{result1, result2}
 }
@@ -601,7 +776,8 @@ func (fake *FakeClient) ListReadGroupsByAccountName(arg1 string) ([]string, erro
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listReadGroupsByAccountNameReturns.result1, fake.listReadGroupsByAccountNameReturns.result2
+	fakeReturns := fake.listReadGroupsByAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
@@ -610,13 +786,22 @@ func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
 	return len(fake.listReadGroupsByAccountNameArgsForCall)
 }
 
+func (fake *FakeClient) ListReadGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
+	fake.ListReadGroupsByAccountNameStub = stub
+}
+
 func (fake *FakeClient) ListReadGroupsByAccountNameArgsForCall(i int) string {
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
-	return fake.listReadGroupsByAccountNameArgsForCall[i].arg1
+	argsForCall := fake.listReadGroupsByAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, result2 error) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	fake.listReadGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -625,6 +810,8 @@ func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, res
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	if fake.listReadGroupsByAccountNameReturnsOnCall == nil {
 		fake.listReadGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -652,7 +839,8 @@ func (fake *FakeClient) ListWriteGroupsByAccountName(arg1 string) ([]string, err
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listWriteGroupsByAccountNameReturns.result1, fake.listWriteGroupsByAccountNameReturns.result2
+	fakeReturns := fake.listWriteGroupsByAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
@@ -661,13 +849,22 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
 	return len(fake.listWriteGroupsByAccountNameArgsForCall)
 }
 
+func (fake *FakeClient) ListWriteGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
+	fake.ListWriteGroupsByAccountNameStub = stub
+}
+
 func (fake *FakeClient) ListWriteGroupsByAccountNameArgsForCall(i int) string {
 	fake.listWriteGroupsByAccountNameMutex.RLock()
 	defer fake.listWriteGroupsByAccountNameMutex.RUnlock()
-	return fake.listWriteGroupsByAccountNameArgsForCall[i].arg1
+	argsForCall := fake.listWriteGroupsByAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, result2 error) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	fake.listWriteGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -676,6 +873,8 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, re
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	if fake.listWriteGroupsByAccountNameReturnsOnCall == nil {
 		fake.listWriteGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -692,8 +891,6 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameReturnsOnCall(i int, result1
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getKubernetesProviderMutex.RLock()
-	defer fake.getKubernetesProviderMutex.RUnlock()
 	fake.createKubernetesProviderMutex.RLock()
 	defer fake.createKubernetesProviderMutex.RUnlock()
 	fake.createKubernetesResourceMutex.RLock()
@@ -702,14 +899,18 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.createReadPermissionMutex.RUnlock()
 	fake.createWritePermissionMutex.RLock()
 	defer fake.createWritePermissionMutex.RUnlock()
+	fake.getKubernetesProviderMutex.RLock()
+	defer fake.getKubernetesProviderMutex.RUnlock()
+	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
 	fake.listKubernetesProvidersMutex.RLock()
 	defer fake.listKubernetesProvidersMutex.RUnlock()
+	fake.listKubernetesProvidersAndPermissionsMutex.RLock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.RUnlock()
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
 	fake.listWriteGroupsByAccountNameMutex.RLock()


### PR DESCRIPTION
- significantly reduces sql calls by using a join to get read/write permissions for providers instead of querying for each provider