### PR TITLE
add search endpoint

### DIFF
--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -3034,3 +3034,115 @@ const payloadRollingRestartManfiest = `[
       }
    }
 ]`
+
+const payloadSearchEmptyResponseWithPageSizeZero = `[
+            {
+              "pageNumber": 1,
+              "pageSize": 0,
+              "query": "default",
+              "results": [],
+              "totalMatches": 0
+            }
+          ]`
+
+const payloadSearchEmptyResponse = `[
+            {
+              "pageNumber": 1,
+              "pageSize": 500,
+              "query": "default",
+              "results": [],
+              "totalMatches": 0
+            }
+          ]`
+
+const payloadSearch = `[
+            {
+              "pageNumber": 1,
+              "pageSize": 500,
+              "query": "default",
+              "results": [
+                {
+                  "account": "account1",
+                  "group": "pod",
+                  "kubernetesKind": "pod",
+                  "name": "pod test-name1",
+                  "namespace": "default",
+                  "provider": "kubernetes",
+                  "region": "default",
+                  "type": "instances"
+                },
+                {
+                  "account": "account1",
+                  "group": "pod",
+                  "kubernetesKind": "pod",
+                  "name": "pod test-name2",
+                  "namespace": "default",
+                  "provider": "kubernetes",
+                  "region": "default",
+                  "type": "instances"
+                },
+                {
+                  "account": "account2",
+                  "group": "pod",
+                  "kubernetesKind": "pod",
+                  "name": "pod test-name1",
+                  "namespace": "default",
+                  "provider": "kubernetes",
+                  "region": "default",
+                  "type": "instances"
+                },
+                {
+                  "account": "account2",
+                  "group": "pod",
+                  "kubernetesKind": "pod",
+                  "name": "pod test-name2",
+                  "namespace": "default",
+                  "provider": "kubernetes",
+                  "region": "default",
+                  "type": "instances"
+                }
+              ],
+              "totalMatches": 4
+            }
+          ]`
+
+const payloadSearchWithPageSizeThree = `[
+            {
+              "pageNumber": 1,
+              "pageSize": 3,
+              "query": "default",
+              "results": [
+                {
+                  "account": "account1",
+                  "group": "pod",
+                  "kubernetesKind": "pod",
+                  "name": "pod test-name1",
+                  "namespace": "default",
+                  "provider": "kubernetes",
+                  "region": "default",
+                  "type": "instances"
+                },
+                {
+                  "account": "account1",
+                  "group": "pod",
+                  "kubernetesKind": "pod",
+                  "name": "pod test-name2",
+                  "namespace": "default",
+                  "provider": "kubernetes",
+                  "region": "default",
+                  "type": "instances"
+                },
+                {
+                  "account": "account2",
+                  "group": "pod",
+                  "kubernetesKind": "pod",
+                  "name": "pod test-name1",
+                  "namespace": "default",
+                  "provider": "kubernetes",
+                  "region": "default",
+                  "type": "instances"
+                }
+              ],
+              "totalMatches": 3
+            }
+          ]`

--- a/pkg/http/core/search.go
+++ b/pkg/http/core/search.go
@@ -1,11 +1,56 @@
 package core
 
 import (
+	"errors"
 	"net/http"
+	"strconv"
 
+	clouddriver "github.com/billiford/go-clouddriver/pkg"
 	"github.com/gin-gonic/gin"
 )
 
+type SearchResponse []Page
+
+type Page struct {
+	PageNumber int `json:"pageNumber"`
+	PageSize   int `json:"pageSize"`
+	// Platform     string       `json:"platform"`
+	Query        string       `json:"query"`
+	Results      []PageResult `json:"results"`
+	TotalMatches int          `json:"totalMatches"`
+}
+
+type PageResult struct {
+	Account        string `json:"account"`
+	Group          string `json:"group"`
+	KubernetesKind string `json:"kubernetesKind"`
+	Name           string `json:"name"`
+	Namespace      string `json:"namespace"`
+	Provider       string `json:"provider"`
+	Region         string `json:"region"`
+	Type           string `json:"type"`
+	Application    string `json:"application,omitempty"`
+	Cluster        string `json:"cluster,omitempty"`
+}
+
 func Search(c *gin.Context) {
+	sr := SearchResponse{}
+	pageSize, _ := strconv.Atoi(c.Query("pageSize"))
+	namespace := c.Query("q")
+	// The "type" query param is the kubernetes kind.
+	kind := c.Query("type")
+	accounts := c.GetHeader("X-Spinnaker-Accounts")
+
+	if kind == "" || namespace == "" {
+		clouddriver.WriteError(c, http.StatusBadRequest, errors.New("must provide query params 'q' and 'type'"))
+		return
+	}
+
+	p := Page{}
+	results := []PageResult{}
+	for _, account := range accounts {
+
+	}
+
 	c.JSON(http.StatusOK, []string{})
 }

--- a/pkg/http/core/search.go
+++ b/pkg/http/core/search.go
@@ -36,39 +36,9 @@ type PageResult struct {
 	Cluster        string `json:"cluster,omitempty"`
 }
 
-// Example response
-//
-// [
-//   {
-//     "pageNumber": 1,
-//     "pageSize": 500,
-//     "platform": "aws",
-//     "query": "spinnaker",
-//     "results": [
-//       {
-//         "account": "gke_github-replication-sandbox_us-central1_sandbox-us-central1-dev",
-//         "group": "deployment",
-//         "kubernetesKind": "deployment",
-//         "name": "deployment spin-fiat",
-//         "namespace": "spinnaker",
-//         "provider": "kubernetes",
-//         "region": "spinnaker",
-//         "type": "serverGroupManagers"
-//       },
-//       {
-//         "account": "gke_github-replication-sandbox_us-central1_sandbox-us-central1-dev",
-//         "group": "deployment",
-//         "kubernetesKind": "deployment",
-//         "name": "deployment spin-front50",
-//         "namespace": "spinnaker",
-//         "provider": "kubernetes",
-//         "region": "spinnaker",
-//         "type": "serverGroupManagers"
-//       }
-// 	   ],
-//     "totalMatches": 2
-//   }
-// ]
+// Generic search endpoint. It currently just handles searching previously deployed
+// Kubernetes resources. It queries the clouddriver DB and does NOT reach out to
+// clusters for live data.
 func Search(c *gin.Context) {
 	sc := sql.Instance(c)
 	pageSize, _ := strconv.Atoi(c.Query("pageSize"))
@@ -79,7 +49,8 @@ func Search(c *gin.Context) {
 	accounts := strings.Split(c.GetHeader("X-Spinnaker-Accounts"), ",")
 
 	if kind == "" || namespace == "" {
-		clouddriver.WriteError(c, http.StatusBadRequest, errors.New("must provide query params 'q' and 'type'"))
+		clouddriver.WriteError(c, http.StatusBadRequest,
+			errors.New("must provide query params 'q' to specify the namespace and 'type' to specify the kind"))
 		return
 	}
 

--- a/pkg/http/core/search_test.go
+++ b/pkg/http/core/search_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Search", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
 				Expect(ce.Error).To(Equal("Bad Request"))
-				Expect(ce.Message).To(Equal("must provide query params 'q' and 'type'"))
+				Expect(ce.Message).To(Equal("must provide query params 'q' to specify the namespace and 'type' to specify the kind"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
 		})

--- a/pkg/http/core/search_test.go
+++ b/pkg/http/core/search_test.go
@@ -1,0 +1,101 @@
+package core_test
+
+import (
+	"errors"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Search", func() {
+	Describe("#Search", func() {
+		accountsHeader := ""
+
+		BeforeEach(func() {
+			setup()
+			uri = svr.URL + "/search?pageSize=500&q=default&type=pod"
+			accountsHeader = "account1,account2"
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		JustBeforeEach(func() {
+			createRequest(http.MethodGet)
+			req.Header.Add("X-Spinnaker-Accounts", accountsHeader)
+			doRequest()
+		})
+
+		When("kind and namespace are not provided", func() {
+			BeforeEach(func() {
+				uri = svr.URL + "/search?pageSize=500"
+			})
+
+			It("returns status bad request", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Message).To(Equal("must provide query params 'q' and 'type'"))
+				Expect(ce.Status).To(Equal(http.StatusBadRequest))
+			})
+		})
+
+		When("an empty account is provided", func() {
+			BeforeEach(func() {
+				accountsHeader = "account1,,account2"
+			})
+
+			It("continues", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadSearchEmptyResponse)
+			})
+		})
+
+		When("pageSize is not provided", func() {
+			BeforeEach(func() {
+				uri = svr.URL + "/search?q=default&type=pod"
+			})
+
+			It("returns an empty response", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadSearchEmptyResponseWithPageSizeZero)
+			})
+		})
+
+		When("listing resource names returns an error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(nil, errors.New("error listing names"))
+			})
+
+			It("continues", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadSearchEmptyResponse)
+			})
+		})
+
+		When("it reached the pageSize limit while listing names", func() {
+			BeforeEach(func() {
+				uri = svr.URL + "/search?pageSize=3&q=default&type=pod"
+				fakeSQLClient.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns([]string{"test-name1", "test-name2"}, nil)
+			})
+
+			It("limits the response", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadSearchWithPageSizeThree)
+			})
+		})
+
+		When("it succeeds", func() {
+			BeforeEach(func() {
+				fakeSQLClient.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns([]string{"test-name1", "test-name2"}, nil)
+			})
+
+			It("succeeds", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadSearch)
+			})
+		})
+	})
+})

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -37,9 +37,11 @@ func Initialize(r *gin.Engine) {
 		// Get results for a task triggered in CreateKubernetesOperation.
 		r.GET("/task/:id", core.GetTask)
 
+		// Generic search endpoint.
+		r.GET("/search", core.Search)
+
 		// Not implemented.
 		r.GET("/securityGroups", core.ListSecurityGroups)
-		r.GET("/search", core.Search)
 
 		// Artifacts controller.
 		r.GET("/artifacts/credentials", core.ListArtifactCredentials)

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -33,6 +33,7 @@ type Client interface {
 	CreateReadPermission(clouddriver.ReadPermission) error
 	CreateWritePermission(clouddriver.WritePermission) error
 	ListKubernetesProviders() ([]kubernetes.Provider, error)
+	ListKubernetesResourcesByAccountNameAndKind(string, string) ([]kubernetes.Resource, error)
 	ListKubernetesResourcesByFields(...string) ([]kubernetes.Resource, error)
 	ListKubernetesResourcesByTaskID(string) ([]kubernetes.Resource, error)
 	ListKubernetesAccountsBySpinnakerApp(string) ([]string, error)
@@ -128,6 +129,19 @@ func (c *client) ListKubernetesProviders() ([]kubernetes.Provider, error) {
 	db := c.db.Select("name, host, ca_data").Find(&ps)
 
 	return ps, db.Error
+}
+
+func (c *client) ListKubernetesClustersByAccountNameAndKind(accountName, kind string) ([]string, error) {
+	var rs []kubernetes.Resource
+	db := c.db.Select("cluster").
+		Where("account_name = ? AND kind = ?", accountName, kind).Find(&rs)
+
+	clusters := []string{}
+	for _, resource := range rs {
+		clusters = append(clusters, resource.Cluster)
+	}
+
+	return clusters, db.Error
 }
 
 func (c *client) ListKubernetesResourcesByTaskID(taskID string) ([]kubernetes.Resource, error) {

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"time"
 
 	clouddriver "github.com/billiford/go-clouddriver/pkg"
@@ -32,13 +33,13 @@ type Client interface {
 	CreateKubernetesResource(kubernetes.Resource) error
 	CreateReadPermission(clouddriver.ReadPermission) error
 	CreateWritePermission(clouddriver.WritePermission) error
+	ListKubernetesAccountsBySpinnakerApp(string) ([]string, error)
 	ListKubernetesClustersByApplication(string) ([]kubernetes.Resource, error)
-	ListKubernetesClustersByAccountNameAndKindAndNamespace(string, string, string) ([]string, error)
 	ListKubernetesProviders() ([]kubernetes.Provider, error)
 	ListKubernetesProvidersAndPermissions() ([]kubernetes.Provider, error)
 	ListKubernetesResourcesByFields(...string) ([]kubernetes.Resource, error)
 	ListKubernetesResourcesByTaskID(string) ([]kubernetes.Resource, error)
-	ListKubernetesAccountsBySpinnakerApp(string) ([]string, error)
+	ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(string, string, string) ([]string, error)
 	ListReadGroupsByAccountName(string) ([]string, error)
 	ListWriteGroupsByAccountName(string) ([]string, error)
 }
@@ -137,21 +138,22 @@ func (c *client) ListKubernetesClustersByApplication(spinnakerApp string) ([]kub
 	return rs, db.Error
 }
 
-func (c *client) ListKubernetesClustersByAccountNameAndKindAndNamespace(accountName, kind, namespace string) ([]string, error) {
-	var rs []kubernetes.Resource
-	db := c.db.Select("cluster").
+func (c *client) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(accountName,
+	kind, namespace string) ([]string, error) {
+	rs := []kubernetes.Resource{}
+	names := []string{}
+	db := c.db.Select("name").
 		Where("account_name = ? AND kind = ? AND namespace = ?",
 			accountName, kind, namespace).
-		Group("cluster").Find(&rs)
+		Group("name").Find(&rs)
 
-	clusters := []string{}
 	for _, r := range rs {
-		if r.Cluster != "" {
-			clusters = append(clusters, r.Cluster)
+		if r.Name != "" {
+			names = append(names, r.Name)
 		}
 	}
 
-	return clusters, db.Error
+	return names, db.Error
 }
 
 func (c *client) ListKubernetesProviders() ([]kubernetes.Provider, error) {
@@ -234,6 +236,11 @@ func (c *client) ListKubernetesProvidersAndPermissions() ([]kubernetes.Provider,
 		provider.Permissions.Write = writeGroups[name]
 		ps = append(ps, provider)
 	}
+
+	// Sort ascending by name.
+	sort.Slice(ps, func(i, j int) bool {
+		return ps[i].Name < ps[j].Name
+	})
 
 	return ps, nil
 }

--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -262,6 +262,36 @@ var _ = Describe("Sql", func() {
 		})
 	})
 
+	Describe("#ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", func() {
+		var names []string
+
+		JustBeforeEach(func() {
+			names, err = c.ListKubernetesResourceNamesByAccountNameAndKindAndNamespace("test-account-name",
+				"test-kind", "test-namespace")
+		})
+
+		When("it succeeds", func() {
+			BeforeEach(func() {
+				sqlRows := sqlmock.NewRows([]string{"name"}).
+					AddRow("name1").
+					AddRow("name2")
+				mock.ExpectQuery(`(?i)^SELECT ` +
+					`name ` +
+					`FROM "kubernetes_resources" ` +
+					` WHERE \(account_name = \? AND ` +
+					`kind = \? AND ` +
+					`namespace = \?\) GROUP BY name$`).
+					WillReturnRows(sqlRows)
+				mock.ExpectCommit()
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+				Expect(names).To(HaveLen(2))
+			})
+		})
+	})
+
 	Describe("#ListKubernetesResourcesByTaskID", func() {
 		var resources []kubernetes.Resource
 

--- a/pkg/sql/sqlfakes/fake_client.go
+++ b/pkg/sql/sqlfakes/fake_client.go
@@ -68,6 +68,19 @@ type FakeClient struct {
 	createWritePermissionReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ListKubernetesAccountsBySpinnakerAppStub        func(string) ([]string, error)
+	listKubernetesAccountsBySpinnakerAppMutex       sync.RWMutex
+	listKubernetesAccountsBySpinnakerAppArgsForCall []struct {
+		arg1 string
+	}
+	listKubernetesAccountsBySpinnakerAppReturns struct {
+		result1 []string
+		result2 error
+	}
+	listKubernetesAccountsBySpinnakerAppReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
 	ListKubernetesClustersByApplicationStub        func(string) ([]kubernetes.Resource, error)
 	listKubernetesClustersByApplicationMutex       sync.RWMutex
 	listKubernetesClustersByApplicationArgsForCall []struct {
@@ -129,16 +142,18 @@ type FakeClient struct {
 		result1 []kubernetes.Resource
 		result2 error
 	}
-	ListKubernetesAccountsBySpinnakerAppStub        func(string) ([]string, error)
-	listKubernetesAccountsBySpinnakerAppMutex       sync.RWMutex
-	listKubernetesAccountsBySpinnakerAppArgsForCall []struct {
+	ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub        func(string, string, string) ([]string, error)
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex       sync.RWMutex
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall []struct {
 		arg1 string
+		arg2 string
+		arg3 string
 	}
-	listKubernetesAccountsBySpinnakerAppReturns struct {
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns struct {
 		result1 []string
 		result2 error
 	}
-	listKubernetesAccountsBySpinnakerAppReturnsOnCall map[int]struct {
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall map[int]struct {
 		result1 []string
 		result2 error
 	}
@@ -415,6 +430,57 @@ func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error)
 	}{result1}
 }
 
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]string, error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	ret, specificReturn := fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)]
+	fake.listKubernetesAccountsBySpinnakerAppArgsForCall = append(fake.listKubernetesAccountsBySpinnakerAppArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("ListKubernetesAccountsBySpinnakerApp", []interface{}{arg1})
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
+	if fake.ListKubernetesAccountsBySpinnakerAppStub != nil {
+		return fake.ListKubernetesAccountsBySpinnakerAppStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.listKubernetesAccountsBySpinnakerAppReturns.result1, fake.listKubernetesAccountsBySpinnakerAppReturns.result2
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
+	return len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppArgsForCall(i int) string {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
+	return fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i].arg1
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []string, result2 error) {
+	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
+	fake.listKubernetesAccountsBySpinnakerAppReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
+	if fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall == nil {
+		fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) ListKubernetesClustersByApplication(arg1 string) ([]kubernetes.Resource, error) {
 	fake.listKubernetesClustersByApplicationMutex.Lock()
 	ret, specificReturn := fake.listKubernetesClustersByApplicationReturnsOnCall[len(fake.listKubernetesClustersByApplicationArgsForCall)]
@@ -654,52 +720,54 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, resu
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]string, error) {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
-	ret, specificReturn := fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)]
-	fake.listKubernetesAccountsBySpinnakerAppArgsForCall = append(fake.listKubernetesAccountsBySpinnakerAppArgsForCall, struct {
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(arg1 string, arg2 string, arg3 string) ([]string, error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	ret, specificReturn := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)]
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall = append(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall, struct {
 		arg1 string
-	}{arg1})
-	fake.recordInvocation("ListKubernetesAccountsBySpinnakerApp", []interface{}{arg1})
-	fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
-	if fake.ListKubernetesAccountsBySpinnakerAppStub != nil {
-		return fake.ListKubernetesAccountsBySpinnakerAppStub(arg1)
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	if fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub != nil {
+		return fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesAccountsBySpinnakerAppReturns.result1, fake.listKubernetesAccountsBySpinnakerAppReturns.result2
+	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result2
 }
 
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
-	return len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCallCount() int {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	return len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppArgsForCall(i int) string {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
-	return fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i].arg1
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall(i int) (string, string, string) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg2, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg3
 }
 
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []string, result2 error) {
-	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
-	fake.listKubernetesAccountsBySpinnakerAppReturns = struct {
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(result1 []string, result2 error) {
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
-	if fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall == nil {
-		fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall = make(map[int]struct {
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	if fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall == nil {
+		fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall = make(map[int]struct {
 			result1 []string
 			result2 error
 		})
 	}
-	fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall[i] = struct {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[i] = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}
@@ -820,6 +888,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.createReadPermissionMutex.RUnlock()
 	fake.createWritePermissionMutex.RLock()
 	defer fake.createWritePermissionMutex.RUnlock()
+	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
 	fake.listKubernetesClustersByApplicationMutex.RLock()
 	defer fake.listKubernetesClustersByApplicationMutex.RUnlock()
 	fake.listKubernetesProvidersMutex.RLock()
@@ -830,8 +900,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
 	fake.listWriteGroupsByAccountNameMutex.RLock()


### PR DESCRIPTION
- add the `/search` endpoint
- return a bad request if the query params `q` (kubernetes namespace) or `type` (kubernetes kind) are not provided
- list accounts provided by the `X-Spinnaker-Accounts` header