### PR TITLE
add artifact credentials controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /clouddriver
-test/
+/test/
 *.coverprofile
 clouddriver.db

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/gddo v0.0.0-20200715224205-051695c33a3f
+	github.com/google/go-github/v32 v32.1.0
 	github.com/google/uuid v1.1.1
 	github.com/jinzhu/gorm v1.9.16
 	github.com/jonboulle/clockwork v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -308,7 +308,11 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=

--- a/pkg/artifact/artifact_suite_test.go
+++ b/pkg/artifact/artifact_suite_test.go
@@ -1,0 +1,13 @@
+package artifact_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestArtifact(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Artifact Suite")
+}

--- a/pkg/artifact/controller.go
+++ b/pkg/artifact/controller.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path/filepath"
 	"strings"
 
@@ -62,8 +61,6 @@ func NewCredentialsController(dir string) (CredentialsController, error) {
 
 	for _, f := range files {
 		if !f.IsDir() {
-			log.Printf("reading artifact credential file %s/%s\n", dir, f.Name())
-
 			b, err := ioutil.ReadFile(filepath.Join(dir, f.Name()))
 			if err != nil {
 				return nil, err
@@ -91,6 +88,10 @@ func NewCredentialsController(dir string) (CredentialsController, error) {
 				t := ac.Types[0]
 				switch t {
 				case TypeHelmChart:
+					if ac.URL == "" {
+						return nil, fmt.Errorf("helm chart %s missing required \"url\" attribute", ac.Name)
+					}
+
 					helmClient := helm.NewClient(ac.URL)
 					cc.helmClients[ac.Name] = helmClient
 				}

--- a/pkg/artifact/controller.go
+++ b/pkg/artifact/controller.go
@@ -1,0 +1,133 @@
+package artifact
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"github.com/billiford/go-clouddriver/pkg/helm"
+	// "github.com/google/go-github/v32/github"
+)
+
+type Type string
+
+const (
+	TypeHelmChart               Type = "helm/chart"
+	TypeGitRepo                 Type = "git/repo"
+	TypeFront50PipelineTemplate Type = "front50/pipelineTemplate"
+	TypeEmbeddedBase64          Type = "embedded/base64"
+	TypeCustomerObject          Type = "custom/object"
+	TypeGCSObject               Type = "gcs/object"
+	TypeDockerImage             Type = "docker/image"
+	TypeKubernetesConfigMap     Type = "kubernetes/configMap"
+	TypeKubernetesDeployment    Type = "kubernetes/deployment"
+	TypeKubernetesReplicaSet    Type = "kubernetes/replicaSet"
+	TypeKubernetesSecret        Type = "kubernetes/secret"
+	TypeGithubFile              Type = "github/file"
+)
+
+type CredentialsController interface {
+	ListArtifactCredentialsNamesAndTypes() []Credentials
+	HelmClientForAccountName(string) (helm.Client, error)
+	// GitClientForAccountName(string) (github.Client, error)
+}
+
+type Credentials struct {
+	Name  string `json:"name"`
+	Types []Type `json:"types"`
+	URL   string `json:"url,omitempty"`
+}
+
+var (
+	defaultConfigDir = "/opt/spinnaker/artifacts/config"
+)
+
+func NewDefaultCredentialsController() (CredentialsController, error) {
+	return NewCredentialsController(defaultConfigDir)
+}
+
+func NewCredentialsController(dir string) (CredentialsController, error) {
+	cc := credentialsController{
+		artifactCredentials: []Credentials{},
+		helmClients:         map[string]helm.Client{},
+	}
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range files {
+		if !f.IsDir() {
+			log.Printf("reading artifact credential file %s/%s\n", dir, f.Name())
+
+			b, err := ioutil.ReadFile(filepath.Join(dir, f.Name()))
+			if err != nil {
+				return nil, err
+			}
+
+			ac := Credentials{}
+
+			err = json.Unmarshal(b, &ac)
+			if err != nil {
+				return nil, err
+			}
+
+			if ac.Name == "" {
+				return nil, fmt.Errorf("no \"name\" found in artifact config file %s", filepath.Join(dir, f.Name()))
+			}
+
+			for _, c := range cc.artifactCredentials {
+				if strings.EqualFold(ac.Name, c.Name) {
+					return nil, fmt.Errorf("duplicate artifact credential listed: %s", ac.Name)
+				}
+			}
+
+			// If artifact credentials is responsible for one type, generate clients as needed.
+			if len(ac.Types) == 1 {
+				t := ac.Types[0]
+				switch t {
+				case TypeHelmChart:
+					helmClient := helm.NewClient(ac.URL)
+					cc.helmClients[ac.Name] = helmClient
+				}
+			}
+
+			cc.artifactCredentials = append(cc.artifactCredentials, ac)
+		}
+	}
+
+	return &cc, nil
+}
+
+type credentialsController struct {
+	artifactCredentials []Credentials
+	helmClients         map[string]helm.Client
+}
+
+// There might be confidential info stored in a artifacts credentials, so we need to be careful
+// what we list here. In this case, only list the names and types.
+func (cc *credentialsController) ListArtifactCredentialsNamesAndTypes() []Credentials {
+	ac := []Credentials{}
+
+	for _, artifaceCredentials := range cc.artifactCredentials {
+		a := Credentials{
+			Name:  artifaceCredentials.Name,
+			Types: artifaceCredentials.Types,
+		}
+		ac = append(ac, a)
+	}
+
+	return ac
+}
+
+func (cc *credentialsController) HelmClientForAccountName(accountName string) (helm.Client, error) {
+	if _, ok := cc.helmClients[accountName]; !ok {
+		return nil, fmt.Errorf("helm account %s not found", accountName)
+	}
+
+	return cc.helmClients[accountName], nil
+}

--- a/pkg/artifact/controller_test.go
+++ b/pkg/artifact/controller_test.go
@@ -1,0 +1,160 @@
+package artifact_test
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	. "github.com/billiford/go-clouddriver/pkg/artifact"
+	"github.com/billiford/go-clouddriver/pkg/helm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		cc  CredentialsController
+		err error
+		dir string
+	)
+
+	BeforeEach(func() {
+		dir = "test"
+		log.SetOutput(ioutil.Discard)
+	})
+
+	Describe("#NewCredentialsController", func() {
+		JustBeforeEach(func() {
+			cc, err = NewCredentialsController(dir)
+		})
+
+		When("the directory does not exist", func() {
+			BeforeEach(func() {
+				dir = "i-dont-exist"
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("open i-dont-exist: no such file or directory"))
+			})
+		})
+
+		When("a file exists with bad json", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "cred*.json")
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("unexpected end of JSON input"))
+			})
+		})
+
+		When("a file exists without specifying a credential name", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "cred*.json")
+				_, err = tmpFile.WriteString("{}")
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix("no \"name\" found in artifact config file test/cred"))
+			})
+		})
+
+		When("a duplicate credential exists", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "cred*.json")
+				_, err = tmpFile.WriteString(`{
+					"name": "helm-test"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix("duplicate artifact credential listed: helm-test"))
+			})
+		})
+
+		When("it succeeds", func() {
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Describe("#ListArtifactCredentialsNamesAndTypes", func() {
+		var artifactCredentials []Credentials
+
+		BeforeEach(func() {
+			cc, err = NewCredentialsController(dir)
+		})
+
+		JustBeforeEach(func() {
+			artifactCredentials = cc.ListArtifactCredentialsNamesAndTypes()
+		})
+
+		When("it succeeds", func() {
+			It("succeeds", func() {
+				Expect(artifactCredentials).To(HaveLen(9))
+				for _, ac := range artifactCredentials {
+					Expect(ac.URL).To(BeEmpty())
+				}
+			})
+		})
+	})
+
+	Describe("#HelmClientForAccountName", func() {
+		var (
+			helmClient  helm.Client
+			accountName string
+		)
+
+		BeforeEach(func() {
+			accountName = "helm-test"
+			cc, err = NewCredentialsController(dir)
+		})
+
+		JustBeforeEach(func() {
+			helmClient, err = cc.HelmClientForAccountName(accountName)
+		})
+
+		When("the account name does not exist in the cache", func() {
+			BeforeEach(func() {
+				accountName = "fake"
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("helm account fake not found"))
+			})
+		})
+
+		When("it succeeds", func() {
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+				Expect(helmClient).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/artifact/controller_test.go
+++ b/pkg/artifact/controller_test.go
@@ -96,6 +96,30 @@ var _ = Describe("Controller", func() {
 			})
 		})
 
+		When("a type helm/chart is missing the url attribute", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "cred*.json")
+				_, err = tmpFile.WriteString(`{
+					"name": "helm-test2",
+					"types": [
+					  "helm/chart"
+					]
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`helm chart helm-test2 missing required "url" attribute`))
+			})
+		})
+
 		When("it succeeds", func() {
 			It("succeeds", func() {
 				Expect(err).To(BeNil())

--- a/pkg/artifact/test/custom-object.json
+++ b/pkg/artifact/test/custom-object.json
@@ -1,0 +1,6 @@
+{
+  "name": "custom-artifact",
+  "types": [
+    "custom/object"
+  ]
+}

--- a/pkg/artifact/test/docker-image.json
+++ b/pkg/artifact/test/docker-image.json
@@ -1,0 +1,6 @@
+{
+  "name": "docker-registry",
+  "types": [
+    "docker/image"
+  ]
+}

--- a/pkg/artifact/test/embedded-base64.json
+++ b/pkg/artifact/test/embedded-base64.json
@@ -1,0 +1,6 @@
+{
+  "name": "embedded-artifact",
+  "types": [
+    "embedded/base64"
+  ]
+}

--- a/pkg/artifact/test/front50-pipeline-template.json
+++ b/pkg/artifact/test/front50-pipeline-template.json
@@ -1,0 +1,6 @@
+{
+  "name": "front50ArtifactCredentials",
+  "types": [
+    "front50/pipelineTemplate"
+  ]
+}

--- a/pkg/artifact/test/gcs-object.json
+++ b/pkg/artifact/test/gcs-object.json
@@ -1,0 +1,6 @@
+{
+  "name": "gcs-spinnaker",
+  "types": [
+    "gcs/object"
+  ]
+}

--- a/pkg/artifact/test/git-repo.json
+++ b/pkg/artifact/test/git-repo.json
@@ -1,0 +1,6 @@
+{
+  "name": "github-spinnaker",
+  "types": [
+    "git/repo"
+  ]
+}

--- a/pkg/artifact/test/github-file.json
+++ b/pkg/artifact/test/github-file.json
@@ -1,0 +1,6 @@
+{
+  "name": "github.com",
+  "types": [
+    "github/file"
+  ]
+}

--- a/pkg/artifact/test/helm-chart.json
+++ b/pkg/artifact/test/helm-chart.json
@@ -1,0 +1,7 @@
+{
+  "name": "helm-test",
+  "types": [
+    "helm/chart"
+  ],
+  "url": "https://kubernetes-charts.storage.googleapis.com"
+}

--- a/pkg/artifact/test/kubernetes.json
+++ b/pkg/artifact/test/kubernetes.json
@@ -1,0 +1,9 @@
+{
+  "name": "kubernetes",
+  "types": [
+    "kubernetes/configMap",
+    "kubernetes/deployment",
+    "kubernetes/replicaSet",
+    "kubernetes/secret"
+  ]
+}


### PR DESCRIPTION
This is the initial effort to allow go-clouddriver to consume artifact credentials at startup.

Go Clouddriver needs to

1) be able to consume multiple credentials and return their names and types to the user

2) create clients for certain types of credentials (helm repos, git, etc)

3) store and retrieve clients for a given account name

By default, the `ArtifactCredentialsController` will read all files in the directory `/opt/spinnaker/artifacts/config`, so we should store these credentials in Kubernetes configMap/secret and mount them there.

The Controller is expecting each file in this directory to contain information about the artifact credentials, examples can be seen in the `pkg/artifact/test/*.json` files.

For this pull request we are only generating helm clients.