### PR TITLE
add namespace field for infrastructure page

### DIFF
--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -116,6 +116,7 @@ type ServerGroupManager struct {
 	Manifest      map[string]interface{}          `json:"manifest"`
 	Moniker       Moniker                         `json:"moniker"`
 	Name          string                          `json:"name"`
+	Namespace     string                          `json:"namespace"`
 	ProviderType  string                          `json:"providerType"`
 	Region        string                          `json:"region"`
 	ServerGroups  []ServerGroupManagerServerGroup `json:"serverGroups"`
@@ -277,6 +278,7 @@ func newServerGroupManager(deployment unstructured.Unstructured,
 			Cluster: fmt.Sprintf("%s %s", "deployment", deployment.GetName()),
 		},
 		Name:         fmt.Sprintf("%s %s", "deployment", deployment.GetName()),
+		Namespace:    deployment.GetNamespace(),
 		ProviderType: "kubernetes",
 		Region:       deployment.GetNamespace(),
 		Type:         "kubernetes",
@@ -543,6 +545,7 @@ type ServerGroup struct {
 	Manifest            map[string]interface{}          `json:"manifest"`
 	Moniker             ServerGroupMoniker              `json:"moniker"`
 	Name                string                          `json:"name"`
+	Namespace           string                          `json:"namespace"`
 	ProviderType        string                          `json:"providerType"`
 	Region              string                          `json:"region"`
 	SecurityGroups      []interface{}                   `json:"securityGroups"`
@@ -775,6 +778,7 @@ func newServerGroup(result unstructured.Unstructured,
 			Sequence: sequence,
 		},
 		Name:                fmt.Sprintf("%s %s", result.GetKind(), result.GetName()),
+		Namespace:           result.GetNamespace(),
 		Region:              result.GetNamespace(),
 		SecurityGroups:      nil,
 		ServerGroupManagers: serverGroupManagers,
@@ -1085,6 +1089,7 @@ func GetServerGroup(c *gin.Context) {
 			Sequence: sequence,
 		},
 		Name:                fmt.Sprintf("%s %s", result.GetKind(), result.GetName()),
+		Namespace:           result.GetNamespace(),
 		ProviderType:        "kubernetes",
 		Region:              result.GetNamespace(),
 		SecurityGroups:      []interface{}{},

--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -1108,6 +1108,7 @@ const payloadServerGroupManagers = `[
                 "cluster": "deployment test-deployment1"
               },
               "name": "deployment test-deployment1",
+              "namespace": "test-namespace1",
               "providerType": "kubernetes",
               "region": "test-namespace1",
               "serverGroups": [
@@ -1162,6 +1163,7 @@ const payloadServerGroupManagers = `[
                 "cluster": "deployment test-deployment2"
               },
               "name": "deployment test-deployment2",
+              "namespace": "test-namespace2",
               "providerType": "kubernetes",
               "region": "test-namespace2",
               "serverGroups": [],
@@ -1217,6 +1219,7 @@ const payloadListServerGroups = `[
                 "sequence": 19
               },
               "name": "DaemonSet test-ds1",
+              "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
               "securityGroups": null,
@@ -1307,6 +1310,7 @@ const payloadListServerGroups = `[
                 "sequence": 19
               },
               "name": "ReplicaSet test-rs1",
+              "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
               "securityGroups": null,
@@ -1397,6 +1401,7 @@ const payloadListServerGroups = `[
                 "sequence": 19
               },
               "name": "StatefulSet test-rs1",
+              "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
               "securityGroups": null,
@@ -2365,6 +2370,7 @@ const payloadGetServerGroup = `{
               "sequence": 19
             },
             "name": "ReplicaSet test-rs1",
+            "namespace": "test-namespace1",
             "providerType": "kubernetes",
             "region": "test-namespace1",
             "securityGroups": [],


### PR DESCRIPTION
Infrastructure page now expects a "namespace" field on returned resources, so we add that here.