### PR TITLE
reference kind in patch manifest name

### DIFF
--- a/pkg/http/core/kubernetes/ops.go
+++ b/pkg/http/core/kubernetes/ops.go
@@ -42,10 +42,10 @@ type DeployManifestRequest struct {
 }
 
 type PatchManifestRequest struct {
-	App           string                         `json:"app"`
-	Cluster       string                         `json:"cluster"`
-	Criteria      string                         `json:"criteria"`
-	Kind          string                         `json:"kind"`
+	App      string `json:"app"`
+	Cluster  string `json:"cluster"`
+	Criteria string `json:"criteria"`
+	// Kind          string                         `json:"kind"`
 	ManifestName  string                         `json:"manifestName"`
 	Source        string                         `json:"source"`
 	Mode          string                         `json:"mode"`

--- a/pkg/http/core/kubernetes/patch.go
+++ b/pkg/http/core/kubernetes/patch.go
@@ -61,7 +61,6 @@ func (p *patchManfest) Run() error {
 		return err
 	}
 
-	// TODO how will this work with other merge types?
 	b, err := json.Marshal(p.pm.PatchBody)
 	if err != nil {
 		return err
@@ -69,10 +68,12 @@ func (p *patchManfest) Run() error {
 
 	// Manifest name is *really* the Spinnaker cluster - i.e. "deployment test-deployment", so we
 	// need to split on a whitespace and get the actual name of the manifest.
+	kind := ""
 	name := p.pm.ManifestName
 
 	a := strings.Split(p.pm.ManifestName, " ")
 	if len(a) > 1 {
+		kind = a[0]
 		name = a[1]
 	}
 
@@ -90,7 +91,7 @@ func (p *patchManfest) Run() error {
 		return fmt.Errorf("invalid merge strategy %s", p.pm.Options.MergeStrategy)
 	}
 
-	meta, _, err := client.PatchUsingStrategy(p.pm.Kind, name, p.pm.Location, b, strategy)
+	meta, _, err := client.PatchUsingStrategy(kind, name, p.pm.Location, b, strategy)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I found the UI is no longer passing "kind" for a patch request so we just grab the kind from the `manifestName` field.