### PR TITLE
Post filter middleware

### DIFF
--- a/pkg/arcade/arcadefakes/fake_client.go
+++ b/pkg/arcade/arcadefakes/fake_client.go
@@ -10,8 +10,9 @@ import (
 type FakeClient struct {
 	TokenStub        func() (string, error)
 	tokenMutex       sync.RWMutex
-	tokenArgsForCall []struct{}
-	tokenReturns     struct {
+	tokenArgsForCall []struct {
+	}
+	tokenReturns struct {
 		result1 string
 		result2 error
 	}
@@ -31,7 +32,8 @@ type FakeClient struct {
 func (fake *FakeClient) Token() (string, error) {
 	fake.tokenMutex.Lock()
 	ret, specificReturn := fake.tokenReturnsOnCall[len(fake.tokenArgsForCall)]
-	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct{}{})
+	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Token", []interface{}{})
 	fake.tokenMutex.Unlock()
 	if fake.TokenStub != nil {
@@ -40,7 +42,8 @@ func (fake *FakeClient) Token() (string, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.tokenReturns.result1, fake.tokenReturns.result2
+	fakeReturns := fake.tokenReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) TokenCallCount() int {
@@ -49,7 +52,15 @@ func (fake *FakeClient) TokenCallCount() int {
 	return len(fake.tokenArgsForCall)
 }
 
+func (fake *FakeClient) TokenCalls(stub func() (string, error)) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
+	fake.TokenStub = stub
+}
+
 func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	fake.tokenReturns = struct {
 		result1 string
@@ -58,6 +69,8 @@ func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeClient) TokenReturnsOnCall(i int, result1 string, result2 error) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	if fake.tokenReturnsOnCall == nil {
 		fake.tokenReturnsOnCall = make(map[int]struct {
@@ -89,10 +102,17 @@ func (fake *FakeClient) WithAPIKeyCallCount() int {
 	return len(fake.withAPIKeyArgsForCall)
 }
 
+func (fake *FakeClient) WithAPIKeyCalls(stub func(string)) {
+	fake.withAPIKeyMutex.Lock()
+	defer fake.withAPIKeyMutex.Unlock()
+	fake.WithAPIKeyStub = stub
+}
+
 func (fake *FakeClient) WithAPIKeyArgsForCall(i int) string {
 	fake.withAPIKeyMutex.RLock()
 	defer fake.withAPIKeyMutex.RUnlock()
-	return fake.withAPIKeyArgsForCall[i].arg1
+	argsForCall := fake.withAPIKeyArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) Invocations() map[string][][]interface{} {

--- a/pkg/artifact/artifactfakes/fake_credentials_controller.go
+++ b/pkg/artifact/artifactfakes/fake_credentials_controller.go
@@ -11,28 +11,6 @@ import (
 )
 
 type FakeCredentialsController struct {
-	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
-	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
-	listArtifactCredentialsNamesAndTypesArgsForCall []struct{}
-	listArtifactCredentialsNamesAndTypesReturns     struct {
-		result1 []artifact.Credentials
-	}
-	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
-		result1 []artifact.Credentials
-	}
-	HelmClientForAccountNameStub        func(string) (helm.Client, error)
-	helmClientForAccountNameMutex       sync.RWMutex
-	helmClientForAccountNameArgsForCall []struct {
-		arg1 string
-	}
-	helmClientForAccountNameReturns struct {
-		result1 helm.Client
-		result2 error
-	}
-	helmClientForAccountNameReturnsOnCall map[int]struct {
-		result1 helm.Client
-		result2 error
-	}
 	GitClientForAccountNameStub        func(string) (*github.Client, error)
 	gitClientForAccountNameMutex       sync.RWMutex
 	gitClientForAccountNameArgsForCall []struct {
@@ -59,99 +37,31 @@ type FakeCredentialsController struct {
 		result1 *http.Client
 		result2 error
 	}
+	HelmClientForAccountNameStub        func(string) (helm.Client, error)
+	helmClientForAccountNameMutex       sync.RWMutex
+	helmClientForAccountNameArgsForCall []struct {
+		arg1 string
+	}
+	helmClientForAccountNameReturns struct {
+		result1 helm.Client
+		result2 error
+	}
+	helmClientForAccountNameReturnsOnCall map[int]struct {
+		result1 helm.Client
+		result2 error
+	}
+	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
+	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
+	listArtifactCredentialsNamesAndTypesArgsForCall []struct {
+	}
+	listArtifactCredentialsNamesAndTypesReturns struct {
+		result1 []artifact.Credentials
+	}
+	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
+		result1 []artifact.Credentials
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
-	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct{}{})
-	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
-	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	if fake.ListArtifactCredentialsNamesAndTypesStub != nil {
-		return fake.ListArtifactCredentialsNamesAndTypesStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.listArtifactCredentialsNamesAndTypesReturns.result1
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
-	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
-	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
-		result1 []artifact.Credentials
-	}{result1}
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
-		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
-			result1 []artifact.Credentials
-		})
-	}
-	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
-		result1 []artifact.Credentials
-	}{result1}
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (helm.Client, error) {
-	fake.helmClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.helmClientForAccountNameReturnsOnCall[len(fake.helmClientForAccountNameArgsForCall)]
-	fake.helmClientForAccountNameArgsForCall = append(fake.helmClientForAccountNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("HelmClientForAccountName", []interface{}{arg1})
-	fake.helmClientForAccountNameMutex.Unlock()
-	if fake.HelmClientForAccountNameStub != nil {
-		return fake.HelmClientForAccountNameStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.helmClientForAccountNameReturns.result1, fake.helmClientForAccountNameReturns.result2
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
-	return len(fake.helmClientForAccountNameArgsForCall)
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameArgsForCall(i int) string {
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
-	return fake.helmClientForAccountNameArgsForCall[i].arg1
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 helm.Client, result2 error) {
-	fake.HelmClientForAccountNameStub = nil
-	fake.helmClientForAccountNameReturns = struct {
-		result1 helm.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i int, result1 helm.Client, result2 error) {
-	fake.HelmClientForAccountNameStub = nil
-	if fake.helmClientForAccountNameReturnsOnCall == nil {
-		fake.helmClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 helm.Client
-			result2 error
-		})
-	}
-	fake.helmClientForAccountNameReturnsOnCall[i] = struct {
-		result1 helm.Client
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*github.Client, error) {
@@ -168,7 +78,8 @@ func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*gi
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.gitClientForAccountNameReturns.result1, fake.gitClientForAccountNameReturns.result2
+	fakeReturns := fake.gitClientForAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
@@ -177,13 +88,22 @@ func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
 	return len(fake.gitClientForAccountNameArgsForCall)
 }
 
+func (fake *FakeCredentialsController) GitClientForAccountNameCalls(stub func(string) (*github.Client, error)) {
+	fake.gitClientForAccountNameMutex.Lock()
+	defer fake.gitClientForAccountNameMutex.Unlock()
+	fake.GitClientForAccountNameStub = stub
+}
+
 func (fake *FakeCredentialsController) GitClientForAccountNameArgsForCall(i int) string {
 	fake.gitClientForAccountNameMutex.RLock()
 	defer fake.gitClientForAccountNameMutex.RUnlock()
-	return fake.gitClientForAccountNameArgsForCall[i].arg1
+	argsForCall := fake.gitClientForAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *github.Client, result2 error) {
+	fake.gitClientForAccountNameMutex.Lock()
+	defer fake.gitClientForAccountNameMutex.Unlock()
 	fake.GitClientForAccountNameStub = nil
 	fake.gitClientForAccountNameReturns = struct {
 		result1 *github.Client
@@ -192,6 +112,8 @@ func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *g
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameReturnsOnCall(i int, result1 *github.Client, result2 error) {
+	fake.gitClientForAccountNameMutex.Lock()
+	defer fake.gitClientForAccountNameMutex.Unlock()
 	fake.GitClientForAccountNameStub = nil
 	if fake.gitClientForAccountNameReturnsOnCall == nil {
 		fake.gitClientForAccountNameReturnsOnCall = make(map[int]struct {
@@ -219,7 +141,8 @@ func (fake *FakeCredentialsController) HTTPClientForAccountName(arg1 string) (*h
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.hTTPClientForAccountNameReturns.result1, fake.hTTPClientForAccountNameReturns.result2
+	fakeReturns := fake.hTTPClientForAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
@@ -228,13 +151,22 @@ func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
 	return len(fake.hTTPClientForAccountNameArgsForCall)
 }
 
+func (fake *FakeCredentialsController) HTTPClientForAccountNameCalls(stub func(string) (*http.Client, error)) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	defer fake.hTTPClientForAccountNameMutex.Unlock()
+	fake.HTTPClientForAccountNameStub = stub
+}
+
 func (fake *FakeCredentialsController) HTTPClientForAccountNameArgsForCall(i int) string {
 	fake.hTTPClientForAccountNameMutex.RLock()
 	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	return fake.hTTPClientForAccountNameArgsForCall[i].arg1
+	argsForCall := fake.hTTPClientForAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *http.Client, result2 error) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	defer fake.hTTPClientForAccountNameMutex.Unlock()
 	fake.HTTPClientForAccountNameStub = nil
 	fake.hTTPClientForAccountNameReturns = struct {
 		result1 *http.Client
@@ -243,6 +175,8 @@ func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *
 }
 
 func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	defer fake.hTTPClientForAccountNameMutex.Unlock()
 	fake.HTTPClientForAccountNameStub = nil
 	if fake.hTTPClientForAccountNameReturnsOnCall == nil {
 		fake.hTTPClientForAccountNameReturnsOnCall = make(map[int]struct {
@@ -256,17 +190,132 @@ func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i i
 	}{result1, result2}
 }
 
+func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (helm.Client, error) {
+	fake.helmClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.helmClientForAccountNameReturnsOnCall[len(fake.helmClientForAccountNameArgsForCall)]
+	fake.helmClientForAccountNameArgsForCall = append(fake.helmClientForAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("HelmClientForAccountName", []interface{}{arg1})
+	fake.helmClientForAccountNameMutex.Unlock()
+	if fake.HelmClientForAccountNameStub != nil {
+		return fake.HelmClientForAccountNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.helmClientForAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	return len(fake.helmClientForAccountNameArgsForCall)
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameCalls(stub func(string) (helm.Client, error)) {
+	fake.helmClientForAccountNameMutex.Lock()
+	defer fake.helmClientForAccountNameMutex.Unlock()
+	fake.HelmClientForAccountNameStub = stub
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameArgsForCall(i int) string {
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	argsForCall := fake.helmClientForAccountNameArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 helm.Client, result2 error) {
+	fake.helmClientForAccountNameMutex.Lock()
+	defer fake.helmClientForAccountNameMutex.Unlock()
+	fake.HelmClientForAccountNameStub = nil
+	fake.helmClientForAccountNameReturns = struct {
+		result1 helm.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i int, result1 helm.Client, result2 error) {
+	fake.helmClientForAccountNameMutex.Lock()
+	defer fake.helmClientForAccountNameMutex.Unlock()
+	fake.HelmClientForAccountNameStub = nil
+	if fake.helmClientForAccountNameReturnsOnCall == nil {
+		fake.helmClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 helm.Client
+			result2 error
+		})
+	}
+	fake.helmClientForAccountNameReturnsOnCall[i] = struct {
+		result1 helm.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
+	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
+	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	if fake.ListArtifactCredentialsNamesAndTypesStub != nil {
+		return fake.ListArtifactCredentialsNamesAndTypesStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.listArtifactCredentialsNamesAndTypesReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
+	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
+	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCalls(stub func() []artifact.Credentials) {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	fake.ListArtifactCredentialsNamesAndTypesStub = stub
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
+		result1 []artifact.Credentials
+	}{result1}
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
+		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
+			result1 []artifact.Credentials
+		})
+	}
+	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
+		result1 []artifact.Credentials
+	}{result1}
+}
+
 func (fake *FakeCredentialsController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
 	fake.gitClientForAccountNameMutex.RLock()
 	defer fake.gitClientForAccountNameMutex.RUnlock()
 	fake.hTTPClientForAccountNameMutex.RLock()
 	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -29,7 +29,6 @@ func NewError(e, m string, s int) Error {
 	}
 }
 
-//Todo refactor to Error
 func WriteError(c *gin.Context, status int, err error) {
 	c.Status(status)
 	c.Error(err).SetType(gin.ErrorTypePublic)

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -29,6 +29,7 @@ func NewError(e, m string, s int) Error {
 	}
 }
 
+//Todo refactor to Error
 func WriteError(c *gin.Context, status int, err error) {
 	c.Status(status)
 	c.Error(err).SetType(gin.ErrorTypePublic)

--- a/pkg/fiat/fiatfakes/fake_client.go
+++ b/pkg/fiat/fiatfakes/fake_client.go
@@ -8,10 +8,10 @@ import (
 )
 
 type FakeClient struct {
-	AuthorizeStub        func(account string) (fiat.Response, error)
+	AuthorizeStub        func(string) (fiat.Response, error)
 	authorizeMutex       sync.RWMutex
 	authorizeArgsForCall []struct {
-		account string
+		arg1 string
 	}
 	authorizeReturns struct {
 		result1 fiat.Response
@@ -25,21 +25,22 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) Authorize(account string) (fiat.Response, error) {
+func (fake *FakeClient) Authorize(arg1 string) (fiat.Response, error) {
 	fake.authorizeMutex.Lock()
 	ret, specificReturn := fake.authorizeReturnsOnCall[len(fake.authorizeArgsForCall)]
 	fake.authorizeArgsForCall = append(fake.authorizeArgsForCall, struct {
-		account string
-	}{account})
-	fake.recordInvocation("Authorize", []interface{}{account})
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Authorize", []interface{}{arg1})
 	fake.authorizeMutex.Unlock()
 	if fake.AuthorizeStub != nil {
-		return fake.AuthorizeStub(account)
+		return fake.AuthorizeStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.authorizeReturns.result1, fake.authorizeReturns.result2
+	fakeReturns := fake.authorizeReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) AuthorizeCallCount() int {
@@ -48,13 +49,22 @@ func (fake *FakeClient) AuthorizeCallCount() int {
 	return len(fake.authorizeArgsForCall)
 }
 
+func (fake *FakeClient) AuthorizeCalls(stub func(string) (fiat.Response, error)) {
+	fake.authorizeMutex.Lock()
+	defer fake.authorizeMutex.Unlock()
+	fake.AuthorizeStub = stub
+}
+
 func (fake *FakeClient) AuthorizeArgsForCall(i int) string {
 	fake.authorizeMutex.RLock()
 	defer fake.authorizeMutex.RUnlock()
-	return fake.authorizeArgsForCall[i].account
+	argsForCall := fake.authorizeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) AuthorizeReturns(result1 fiat.Response, result2 error) {
+	fake.authorizeMutex.Lock()
+	defer fake.authorizeMutex.Unlock()
 	fake.AuthorizeStub = nil
 	fake.authorizeReturns = struct {
 		result1 fiat.Response
@@ -63,6 +73,8 @@ func (fake *FakeClient) AuthorizeReturns(result1 fiat.Response, result2 error) {
 }
 
 func (fake *FakeClient) AuthorizeReturnsOnCall(i int, result1 fiat.Response, result2 error) {
+	fake.authorizeMutex.Lock()
+	defer fake.authorizeMutex.Unlock()
 	fake.AuthorizeStub = nil
 	if fake.authorizeReturnsOnCall == nil {
 		fake.authorizeReturnsOnCall = make(map[int]struct {

--- a/pkg/helm/helmfakes/fake_client.go
+++ b/pkg/helm/helmfakes/fake_client.go
@@ -8,17 +8,6 @@ import (
 )
 
 type FakeClient struct {
-	GetIndexStub        func() (helm.Index, error)
-	getIndexMutex       sync.RWMutex
-	getIndexArgsForCall []struct{}
-	getIndexReturns     struct {
-		result1 helm.Index
-		result2 error
-	}
-	getIndexReturnsOnCall map[int]struct {
-		result1 helm.Index
-		result2 error
-	}
 	GetChartStub        func(string, string) ([]byte, error)
 	getChartMutex       sync.RWMutex
 	getChartArgsForCall []struct {
@@ -33,51 +22,20 @@ type FakeClient struct {
 		result1 []byte
 		result2 error
 	}
+	GetIndexStub        func() (helm.Index, error)
+	getIndexMutex       sync.RWMutex
+	getIndexArgsForCall []struct {
+	}
+	getIndexReturns struct {
+		result1 helm.Index
+		result2 error
+	}
+	getIndexReturnsOnCall map[int]struct {
+		result1 helm.Index
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeClient) GetIndex() (helm.Index, error) {
-	fake.getIndexMutex.Lock()
-	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
-	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct{}{})
-	fake.recordInvocation("GetIndex", []interface{}{})
-	fake.getIndexMutex.Unlock()
-	if fake.GetIndexStub != nil {
-		return fake.GetIndexStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.getIndexReturns.result1, fake.getIndexReturns.result2
-}
-
-func (fake *FakeClient) GetIndexCallCount() int {
-	fake.getIndexMutex.RLock()
-	defer fake.getIndexMutex.RUnlock()
-	return len(fake.getIndexArgsForCall)
-}
-
-func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
-	fake.GetIndexStub = nil
-	fake.getIndexReturns = struct {
-		result1 helm.Index
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2 error) {
-	fake.GetIndexStub = nil
-	if fake.getIndexReturnsOnCall == nil {
-		fake.getIndexReturnsOnCall = make(map[int]struct {
-			result1 helm.Index
-			result2 error
-		})
-	}
-	fake.getIndexReturnsOnCall[i] = struct {
-		result1 helm.Index
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
@@ -95,7 +53,8 @@ func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getChartReturns.result1, fake.getChartReturns.result2
+	fakeReturns := fake.getChartReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GetChartCallCount() int {
@@ -104,13 +63,22 @@ func (fake *FakeClient) GetChartCallCount() int {
 	return len(fake.getChartArgsForCall)
 }
 
+func (fake *FakeClient) GetChartCalls(stub func(string, string) ([]byte, error)) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
+	fake.GetChartStub = stub
+}
+
 func (fake *FakeClient) GetChartArgsForCall(i int) (string, string) {
 	fake.getChartMutex.RLock()
 	defer fake.getChartMutex.RUnlock()
-	return fake.getChartArgsForCall[i].arg1, fake.getChartArgsForCall[i].arg2
+	argsForCall := fake.getChartArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
 	fake.GetChartStub = nil
 	fake.getChartReturns = struct {
 		result1 []byte
@@ -119,6 +87,8 @@ func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
 }
 
 func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
 	fake.GetChartStub = nil
 	if fake.getChartReturnsOnCall == nil {
 		fake.getChartReturnsOnCall = make(map[int]struct {
@@ -132,13 +102,68 @@ func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 err
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GetIndex() (helm.Index, error) {
+	fake.getIndexMutex.Lock()
+	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
+	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct {
+	}{})
+	fake.recordInvocation("GetIndex", []interface{}{})
+	fake.getIndexMutex.Unlock()
+	if fake.GetIndexStub != nil {
+		return fake.GetIndexStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getIndexReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetIndexCallCount() int {
+	fake.getIndexMutex.RLock()
+	defer fake.getIndexMutex.RUnlock()
+	return len(fake.getIndexArgsForCall)
+}
+
+func (fake *FakeClient) GetIndexCalls(stub func() (helm.Index, error)) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = stub
+}
+
+func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = nil
+	fake.getIndexReturns = struct {
+		result1 helm.Index
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2 error) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = nil
+	if fake.getIndexReturnsOnCall == nil {
+		fake.getIndexReturnsOnCall = make(map[int]struct {
+			result1 helm.Index
+			result2 error
+		})
+	}
+	fake.getIndexReturnsOnCall[i] = struct {
+		result1 helm.Index
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getIndexMutex.RLock()
-	defer fake.getIndexMutex.RUnlock()
 	fake.getChartMutex.RLock()
 	defer fake.getChartMutex.RUnlock()
+	fake.getIndexMutex.RLock()
+	defer fake.getIndexMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -38,6 +38,8 @@ type ApplicationAttributes struct {
 	Name string `json:"name"`
 }
 
+const KeyAllApplications = `AllApplications`
+
 func ListApplications(c *gin.Context) {
 	sc := sql.Instance(c)
 
@@ -62,7 +64,7 @@ func ListApplications(c *gin.Context) {
 		response = append(response, application)
 	}
 
-	c.JSON(http.StatusOK, response)
+	c.Set(KeyAllApplications, response)
 }
 
 func uniqueSpinnakerApps(rs []kubernetes.Resource) []string {

--- a/pkg/http/core/kubernetes/kubernetesfakes/fake_action.go
+++ b/pkg/http/core/kubernetes/kubernetesfakes/fake_action.go
@@ -10,8 +10,9 @@ import (
 type FakeAction struct {
 	RunStub        func() error
 	runMutex       sync.RWMutex
-	runArgsForCall []struct{}
-	runReturns     struct {
+	runArgsForCall []struct {
+	}
+	runReturns struct {
 		result1 error
 	}
 	runReturnsOnCall map[int]struct {
@@ -24,7 +25,8 @@ type FakeAction struct {
 func (fake *FakeAction) Run() error {
 	fake.runMutex.Lock()
 	ret, specificReturn := fake.runReturnsOnCall[len(fake.runArgsForCall)]
-	fake.runArgsForCall = append(fake.runArgsForCall, struct{}{})
+	fake.runArgsForCall = append(fake.runArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Run", []interface{}{})
 	fake.runMutex.Unlock()
 	if fake.RunStub != nil {
@@ -33,7 +35,8 @@ func (fake *FakeAction) Run() error {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.runReturns.result1
+	fakeReturns := fake.runReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeAction) RunCallCount() int {
@@ -42,7 +45,15 @@ func (fake *FakeAction) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
+func (fake *FakeAction) RunCalls(stub func() error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
+	fake.RunStub = stub
+}
+
 func (fake *FakeAction) RunReturns(result1 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	fake.runReturns = struct {
 		result1 error
@@ -50,6 +61,8 @@ func (fake *FakeAction) RunReturns(result1 error) {
 }
 
 func (fake *FakeAction) RunReturnsOnCall(i int, result1 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	if fake.runReturnsOnCall == nil {
 		fake.runReturnsOnCall = make(map[int]struct {

--- a/pkg/http/core/kubernetes/kubernetesfakes/fake_action_handler.go
+++ b/pkg/http/core/kubernetes/kubernetesfakes/fake_action_handler.go
@@ -19,17 +19,6 @@ type FakeActionHandler struct {
 	newCleanupArtifactsActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
-	NewDeployManifestActionStub        func(kubernetes.ActionConfig) kubernetes.Action
-	newDeployManifestActionMutex       sync.RWMutex
-	newDeployManifestActionArgsForCall []struct {
-		arg1 kubernetes.ActionConfig
-	}
-	newDeployManifestActionReturns struct {
-		result1 kubernetes.Action
-	}
-	newDeployManifestActionReturnsOnCall map[int]struct {
-		result1 kubernetes.Action
-	}
 	NewDeleteManifestActionStub        func(kubernetes.ActionConfig) kubernetes.Action
 	newDeleteManifestActionMutex       sync.RWMutex
 	newDeleteManifestActionArgsForCall []struct {
@@ -41,15 +30,26 @@ type FakeActionHandler struct {
 	newDeleteManifestActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
-	NewRollingRestartActionStub        func(kubernetes.ActionConfig) kubernetes.Action
-	newRollingRestartActionMutex       sync.RWMutex
-	newRollingRestartActionArgsForCall []struct {
+	NewDeployManifestActionStub        func(kubernetes.ActionConfig) kubernetes.Action
+	newDeployManifestActionMutex       sync.RWMutex
+	newDeployManifestActionArgsForCall []struct {
 		arg1 kubernetes.ActionConfig
 	}
-	newRollingRestartActionReturns struct {
+	newDeployManifestActionReturns struct {
 		result1 kubernetes.Action
 	}
-	newRollingRestartActionReturnsOnCall map[int]struct {
+	newDeployManifestActionReturnsOnCall map[int]struct {
+		result1 kubernetes.Action
+	}
+	NewPatchManifestActionStub        func(kubernetes.ActionConfig) kubernetes.Action
+	newPatchManifestActionMutex       sync.RWMutex
+	newPatchManifestActionArgsForCall []struct {
+		arg1 kubernetes.ActionConfig
+	}
+	newPatchManifestActionReturns struct {
+		result1 kubernetes.Action
+	}
+	newPatchManifestActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
 	NewRollbackActionStub        func(kubernetes.ActionConfig) kubernetes.Action
@@ -61,6 +61,17 @@ type FakeActionHandler struct {
 		result1 kubernetes.Action
 	}
 	newRollbackActionReturnsOnCall map[int]struct {
+		result1 kubernetes.Action
+	}
+	NewRollingRestartActionStub        func(kubernetes.ActionConfig) kubernetes.Action
+	newRollingRestartActionMutex       sync.RWMutex
+	newRollingRestartActionArgsForCall []struct {
+		arg1 kubernetes.ActionConfig
+	}
+	newRollingRestartActionReturns struct {
+		result1 kubernetes.Action
+	}
+	newRollingRestartActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
 	NewRunJobActionStub        func(kubernetes.ActionConfig) kubernetes.Action
@@ -85,17 +96,6 @@ type FakeActionHandler struct {
 	newScaleManifestActionReturnsOnCall map[int]struct {
 		result1 kubernetes.Action
 	}
-	NewPatchManifestActionStub        func(kubernetes.ActionConfig) kubernetes.Action
-	newPatchManifestActionMutex       sync.RWMutex
-	newPatchManifestActionArgsForCall []struct {
-		arg1 kubernetes.ActionConfig
-	}
-	newPatchManifestActionReturns struct {
-		result1 kubernetes.Action
-	}
-	newPatchManifestActionReturnsOnCall map[int]struct {
-		result1 kubernetes.Action
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -114,7 +114,8 @@ func (fake *FakeActionHandler) NewCleanupArtifactsAction(arg1 kubernetes.ActionC
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newCleanupArtifactsActionReturns.result1
+	fakeReturns := fake.newCleanupArtifactsActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewCleanupArtifactsActionCallCount() int {
@@ -123,13 +124,22 @@ func (fake *FakeActionHandler) NewCleanupArtifactsActionCallCount() int {
 	return len(fake.newCleanupArtifactsActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewCleanupArtifactsActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newCleanupArtifactsActionMutex.Lock()
+	defer fake.newCleanupArtifactsActionMutex.Unlock()
+	fake.NewCleanupArtifactsActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewCleanupArtifactsActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newCleanupArtifactsActionMutex.RLock()
 	defer fake.newCleanupArtifactsActionMutex.RUnlock()
-	return fake.newCleanupArtifactsActionArgsForCall[i].arg1
+	argsForCall := fake.newCleanupArtifactsActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewCleanupArtifactsActionReturns(result1 kubernetes.Action) {
+	fake.newCleanupArtifactsActionMutex.Lock()
+	defer fake.newCleanupArtifactsActionMutex.Unlock()
 	fake.NewCleanupArtifactsActionStub = nil
 	fake.newCleanupArtifactsActionReturns = struct {
 		result1 kubernetes.Action
@@ -137,6 +147,8 @@ func (fake *FakeActionHandler) NewCleanupArtifactsActionReturns(result1 kubernet
 }
 
 func (fake *FakeActionHandler) NewCleanupArtifactsActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newCleanupArtifactsActionMutex.Lock()
+	defer fake.newCleanupArtifactsActionMutex.Unlock()
 	fake.NewCleanupArtifactsActionStub = nil
 	if fake.newCleanupArtifactsActionReturnsOnCall == nil {
 		fake.newCleanupArtifactsActionReturnsOnCall = make(map[int]struct {
@@ -144,54 +156,6 @@ func (fake *FakeActionHandler) NewCleanupArtifactsActionReturnsOnCall(i int, res
 		})
 	}
 	fake.newCleanupArtifactsActionReturnsOnCall[i] = struct {
-		result1 kubernetes.Action
-	}{result1}
-}
-
-func (fake *FakeActionHandler) NewDeployManifestAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
-	fake.newDeployManifestActionMutex.Lock()
-	ret, specificReturn := fake.newDeployManifestActionReturnsOnCall[len(fake.newDeployManifestActionArgsForCall)]
-	fake.newDeployManifestActionArgsForCall = append(fake.newDeployManifestActionArgsForCall, struct {
-		arg1 kubernetes.ActionConfig
-	}{arg1})
-	fake.recordInvocation("NewDeployManifestAction", []interface{}{arg1})
-	fake.newDeployManifestActionMutex.Unlock()
-	if fake.NewDeployManifestActionStub != nil {
-		return fake.NewDeployManifestActionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.newDeployManifestActionReturns.result1
-}
-
-func (fake *FakeActionHandler) NewDeployManifestActionCallCount() int {
-	fake.newDeployManifestActionMutex.RLock()
-	defer fake.newDeployManifestActionMutex.RUnlock()
-	return len(fake.newDeployManifestActionArgsForCall)
-}
-
-func (fake *FakeActionHandler) NewDeployManifestActionArgsForCall(i int) kubernetes.ActionConfig {
-	fake.newDeployManifestActionMutex.RLock()
-	defer fake.newDeployManifestActionMutex.RUnlock()
-	return fake.newDeployManifestActionArgsForCall[i].arg1
-}
-
-func (fake *FakeActionHandler) NewDeployManifestActionReturns(result1 kubernetes.Action) {
-	fake.NewDeployManifestActionStub = nil
-	fake.newDeployManifestActionReturns = struct {
-		result1 kubernetes.Action
-	}{result1}
-}
-
-func (fake *FakeActionHandler) NewDeployManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
-	fake.NewDeployManifestActionStub = nil
-	if fake.newDeployManifestActionReturnsOnCall == nil {
-		fake.newDeployManifestActionReturnsOnCall = make(map[int]struct {
-			result1 kubernetes.Action
-		})
-	}
-	fake.newDeployManifestActionReturnsOnCall[i] = struct {
 		result1 kubernetes.Action
 	}{result1}
 }
@@ -210,7 +174,8 @@ func (fake *FakeActionHandler) NewDeleteManifestAction(arg1 kubernetes.ActionCon
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newDeleteManifestActionReturns.result1
+	fakeReturns := fake.newDeleteManifestActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewDeleteManifestActionCallCount() int {
@@ -219,13 +184,22 @@ func (fake *FakeActionHandler) NewDeleteManifestActionCallCount() int {
 	return len(fake.newDeleteManifestActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewDeleteManifestActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newDeleteManifestActionMutex.Lock()
+	defer fake.newDeleteManifestActionMutex.Unlock()
+	fake.NewDeleteManifestActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewDeleteManifestActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newDeleteManifestActionMutex.RLock()
 	defer fake.newDeleteManifestActionMutex.RUnlock()
-	return fake.newDeleteManifestActionArgsForCall[i].arg1
+	argsForCall := fake.newDeleteManifestActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewDeleteManifestActionReturns(result1 kubernetes.Action) {
+	fake.newDeleteManifestActionMutex.Lock()
+	defer fake.newDeleteManifestActionMutex.Unlock()
 	fake.NewDeleteManifestActionStub = nil
 	fake.newDeleteManifestActionReturns = struct {
 		result1 kubernetes.Action
@@ -233,6 +207,8 @@ func (fake *FakeActionHandler) NewDeleteManifestActionReturns(result1 kubernetes
 }
 
 func (fake *FakeActionHandler) NewDeleteManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newDeleteManifestActionMutex.Lock()
+	defer fake.newDeleteManifestActionMutex.Unlock()
 	fake.NewDeleteManifestActionStub = nil
 	if fake.newDeleteManifestActionReturnsOnCall == nil {
 		fake.newDeleteManifestActionReturnsOnCall = make(map[int]struct {
@@ -244,50 +220,122 @@ func (fake *FakeActionHandler) NewDeleteManifestActionReturnsOnCall(i int, resul
 	}{result1}
 }
 
-func (fake *FakeActionHandler) NewRollingRestartAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
-	fake.newRollingRestartActionMutex.Lock()
-	ret, specificReturn := fake.newRollingRestartActionReturnsOnCall[len(fake.newRollingRestartActionArgsForCall)]
-	fake.newRollingRestartActionArgsForCall = append(fake.newRollingRestartActionArgsForCall, struct {
+func (fake *FakeActionHandler) NewDeployManifestAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
+	fake.newDeployManifestActionMutex.Lock()
+	ret, specificReturn := fake.newDeployManifestActionReturnsOnCall[len(fake.newDeployManifestActionArgsForCall)]
+	fake.newDeployManifestActionArgsForCall = append(fake.newDeployManifestActionArgsForCall, struct {
 		arg1 kubernetes.ActionConfig
 	}{arg1})
-	fake.recordInvocation("NewRollingRestartAction", []interface{}{arg1})
-	fake.newRollingRestartActionMutex.Unlock()
-	if fake.NewRollingRestartActionStub != nil {
-		return fake.NewRollingRestartActionStub(arg1)
+	fake.recordInvocation("NewDeployManifestAction", []interface{}{arg1})
+	fake.newDeployManifestActionMutex.Unlock()
+	if fake.NewDeployManifestActionStub != nil {
+		return fake.NewDeployManifestActionStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newRollingRestartActionReturns.result1
+	fakeReturns := fake.newDeployManifestActionReturns
+	return fakeReturns.result1
 }
 
-func (fake *FakeActionHandler) NewRollingRestartActionCallCount() int {
-	fake.newRollingRestartActionMutex.RLock()
-	defer fake.newRollingRestartActionMutex.RUnlock()
-	return len(fake.newRollingRestartActionArgsForCall)
+func (fake *FakeActionHandler) NewDeployManifestActionCallCount() int {
+	fake.newDeployManifestActionMutex.RLock()
+	defer fake.newDeployManifestActionMutex.RUnlock()
+	return len(fake.newDeployManifestActionArgsForCall)
 }
 
-func (fake *FakeActionHandler) NewRollingRestartActionArgsForCall(i int) kubernetes.ActionConfig {
-	fake.newRollingRestartActionMutex.RLock()
-	defer fake.newRollingRestartActionMutex.RUnlock()
-	return fake.newRollingRestartActionArgsForCall[i].arg1
+func (fake *FakeActionHandler) NewDeployManifestActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newDeployManifestActionMutex.Lock()
+	defer fake.newDeployManifestActionMutex.Unlock()
+	fake.NewDeployManifestActionStub = stub
 }
 
-func (fake *FakeActionHandler) NewRollingRestartActionReturns(result1 kubernetes.Action) {
-	fake.NewRollingRestartActionStub = nil
-	fake.newRollingRestartActionReturns = struct {
+func (fake *FakeActionHandler) NewDeployManifestActionArgsForCall(i int) kubernetes.ActionConfig {
+	fake.newDeployManifestActionMutex.RLock()
+	defer fake.newDeployManifestActionMutex.RUnlock()
+	argsForCall := fake.newDeployManifestActionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeActionHandler) NewDeployManifestActionReturns(result1 kubernetes.Action) {
+	fake.newDeployManifestActionMutex.Lock()
+	defer fake.newDeployManifestActionMutex.Unlock()
+	fake.NewDeployManifestActionStub = nil
+	fake.newDeployManifestActionReturns = struct {
 		result1 kubernetes.Action
 	}{result1}
 }
 
-func (fake *FakeActionHandler) NewRollingRestartActionReturnsOnCall(i int, result1 kubernetes.Action) {
-	fake.NewRollingRestartActionStub = nil
-	if fake.newRollingRestartActionReturnsOnCall == nil {
-		fake.newRollingRestartActionReturnsOnCall = make(map[int]struct {
+func (fake *FakeActionHandler) NewDeployManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newDeployManifestActionMutex.Lock()
+	defer fake.newDeployManifestActionMutex.Unlock()
+	fake.NewDeployManifestActionStub = nil
+	if fake.newDeployManifestActionReturnsOnCall == nil {
+		fake.newDeployManifestActionReturnsOnCall = make(map[int]struct {
 			result1 kubernetes.Action
 		})
 	}
-	fake.newRollingRestartActionReturnsOnCall[i] = struct {
+	fake.newDeployManifestActionReturnsOnCall[i] = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
+func (fake *FakeActionHandler) NewPatchManifestAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
+	fake.newPatchManifestActionMutex.Lock()
+	ret, specificReturn := fake.newPatchManifestActionReturnsOnCall[len(fake.newPatchManifestActionArgsForCall)]
+	fake.newPatchManifestActionArgsForCall = append(fake.newPatchManifestActionArgsForCall, struct {
+		arg1 kubernetes.ActionConfig
+	}{arg1})
+	fake.recordInvocation("NewPatchManifestAction", []interface{}{arg1})
+	fake.newPatchManifestActionMutex.Unlock()
+	if fake.NewPatchManifestActionStub != nil {
+		return fake.NewPatchManifestActionStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.newPatchManifestActionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionCallCount() int {
+	fake.newPatchManifestActionMutex.RLock()
+	defer fake.newPatchManifestActionMutex.RUnlock()
+	return len(fake.newPatchManifestActionArgsForCall)
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newPatchManifestActionMutex.Lock()
+	defer fake.newPatchManifestActionMutex.Unlock()
+	fake.NewPatchManifestActionStub = stub
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionArgsForCall(i int) kubernetes.ActionConfig {
+	fake.newPatchManifestActionMutex.RLock()
+	defer fake.newPatchManifestActionMutex.RUnlock()
+	argsForCall := fake.newPatchManifestActionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionReturns(result1 kubernetes.Action) {
+	fake.newPatchManifestActionMutex.Lock()
+	defer fake.newPatchManifestActionMutex.Unlock()
+	fake.NewPatchManifestActionStub = nil
+	fake.newPatchManifestActionReturns = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
+func (fake *FakeActionHandler) NewPatchManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newPatchManifestActionMutex.Lock()
+	defer fake.newPatchManifestActionMutex.Unlock()
+	fake.NewPatchManifestActionStub = nil
+	if fake.newPatchManifestActionReturnsOnCall == nil {
+		fake.newPatchManifestActionReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Action
+		})
+	}
+	fake.newPatchManifestActionReturnsOnCall[i] = struct {
 		result1 kubernetes.Action
 	}{result1}
 }
@@ -306,7 +354,8 @@ func (fake *FakeActionHandler) NewRollbackAction(arg1 kubernetes.ActionConfig) k
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newRollbackActionReturns.result1
+	fakeReturns := fake.newRollbackActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewRollbackActionCallCount() int {
@@ -315,13 +364,22 @@ func (fake *FakeActionHandler) NewRollbackActionCallCount() int {
 	return len(fake.newRollbackActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewRollbackActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newRollbackActionMutex.Lock()
+	defer fake.newRollbackActionMutex.Unlock()
+	fake.NewRollbackActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewRollbackActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newRollbackActionMutex.RLock()
 	defer fake.newRollbackActionMutex.RUnlock()
-	return fake.newRollbackActionArgsForCall[i].arg1
+	argsForCall := fake.newRollbackActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewRollbackActionReturns(result1 kubernetes.Action) {
+	fake.newRollbackActionMutex.Lock()
+	defer fake.newRollbackActionMutex.Unlock()
 	fake.NewRollbackActionStub = nil
 	fake.newRollbackActionReturns = struct {
 		result1 kubernetes.Action
@@ -329,6 +387,8 @@ func (fake *FakeActionHandler) NewRollbackActionReturns(result1 kubernetes.Actio
 }
 
 func (fake *FakeActionHandler) NewRollbackActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newRollbackActionMutex.Lock()
+	defer fake.newRollbackActionMutex.Unlock()
 	fake.NewRollbackActionStub = nil
 	if fake.newRollbackActionReturnsOnCall == nil {
 		fake.newRollbackActionReturnsOnCall = make(map[int]struct {
@@ -336,6 +396,66 @@ func (fake *FakeActionHandler) NewRollbackActionReturnsOnCall(i int, result1 kub
 		})
 	}
 	fake.newRollbackActionReturnsOnCall[i] = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
+func (fake *FakeActionHandler) NewRollingRestartAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
+	fake.newRollingRestartActionMutex.Lock()
+	ret, specificReturn := fake.newRollingRestartActionReturnsOnCall[len(fake.newRollingRestartActionArgsForCall)]
+	fake.newRollingRestartActionArgsForCall = append(fake.newRollingRestartActionArgsForCall, struct {
+		arg1 kubernetes.ActionConfig
+	}{arg1})
+	fake.recordInvocation("NewRollingRestartAction", []interface{}{arg1})
+	fake.newRollingRestartActionMutex.Unlock()
+	if fake.NewRollingRestartActionStub != nil {
+		return fake.NewRollingRestartActionStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.newRollingRestartActionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionCallCount() int {
+	fake.newRollingRestartActionMutex.RLock()
+	defer fake.newRollingRestartActionMutex.RUnlock()
+	return len(fake.newRollingRestartActionArgsForCall)
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newRollingRestartActionMutex.Lock()
+	defer fake.newRollingRestartActionMutex.Unlock()
+	fake.NewRollingRestartActionStub = stub
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionArgsForCall(i int) kubernetes.ActionConfig {
+	fake.newRollingRestartActionMutex.RLock()
+	defer fake.newRollingRestartActionMutex.RUnlock()
+	argsForCall := fake.newRollingRestartActionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionReturns(result1 kubernetes.Action) {
+	fake.newRollingRestartActionMutex.Lock()
+	defer fake.newRollingRestartActionMutex.Unlock()
+	fake.NewRollingRestartActionStub = nil
+	fake.newRollingRestartActionReturns = struct {
+		result1 kubernetes.Action
+	}{result1}
+}
+
+func (fake *FakeActionHandler) NewRollingRestartActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newRollingRestartActionMutex.Lock()
+	defer fake.newRollingRestartActionMutex.Unlock()
+	fake.NewRollingRestartActionStub = nil
+	if fake.newRollingRestartActionReturnsOnCall == nil {
+		fake.newRollingRestartActionReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Action
+		})
+	}
+	fake.newRollingRestartActionReturnsOnCall[i] = struct {
 		result1 kubernetes.Action
 	}{result1}
 }
@@ -354,7 +474,8 @@ func (fake *FakeActionHandler) NewRunJobAction(arg1 kubernetes.ActionConfig) kub
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newRunJobActionReturns.result1
+	fakeReturns := fake.newRunJobActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewRunJobActionCallCount() int {
@@ -363,13 +484,22 @@ func (fake *FakeActionHandler) NewRunJobActionCallCount() int {
 	return len(fake.newRunJobActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewRunJobActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newRunJobActionMutex.Lock()
+	defer fake.newRunJobActionMutex.Unlock()
+	fake.NewRunJobActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewRunJobActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newRunJobActionMutex.RLock()
 	defer fake.newRunJobActionMutex.RUnlock()
-	return fake.newRunJobActionArgsForCall[i].arg1
+	argsForCall := fake.newRunJobActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewRunJobActionReturns(result1 kubernetes.Action) {
+	fake.newRunJobActionMutex.Lock()
+	defer fake.newRunJobActionMutex.Unlock()
 	fake.NewRunJobActionStub = nil
 	fake.newRunJobActionReturns = struct {
 		result1 kubernetes.Action
@@ -377,6 +507,8 @@ func (fake *FakeActionHandler) NewRunJobActionReturns(result1 kubernetes.Action)
 }
 
 func (fake *FakeActionHandler) NewRunJobActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newRunJobActionMutex.Lock()
+	defer fake.newRunJobActionMutex.Unlock()
 	fake.NewRunJobActionStub = nil
 	if fake.newRunJobActionReturnsOnCall == nil {
 		fake.newRunJobActionReturnsOnCall = make(map[int]struct {
@@ -402,7 +534,8 @@ func (fake *FakeActionHandler) NewScaleManifestAction(arg1 kubernetes.ActionConf
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.newScaleManifestActionReturns.result1
+	fakeReturns := fake.newScaleManifestActionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeActionHandler) NewScaleManifestActionCallCount() int {
@@ -411,13 +544,22 @@ func (fake *FakeActionHandler) NewScaleManifestActionCallCount() int {
 	return len(fake.newScaleManifestActionArgsForCall)
 }
 
+func (fake *FakeActionHandler) NewScaleManifestActionCalls(stub func(kubernetes.ActionConfig) kubernetes.Action) {
+	fake.newScaleManifestActionMutex.Lock()
+	defer fake.newScaleManifestActionMutex.Unlock()
+	fake.NewScaleManifestActionStub = stub
+}
+
 func (fake *FakeActionHandler) NewScaleManifestActionArgsForCall(i int) kubernetes.ActionConfig {
 	fake.newScaleManifestActionMutex.RLock()
 	defer fake.newScaleManifestActionMutex.RUnlock()
-	return fake.newScaleManifestActionArgsForCall[i].arg1
+	argsForCall := fake.newScaleManifestActionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeActionHandler) NewScaleManifestActionReturns(result1 kubernetes.Action) {
+	fake.newScaleManifestActionMutex.Lock()
+	defer fake.newScaleManifestActionMutex.Unlock()
 	fake.NewScaleManifestActionStub = nil
 	fake.newScaleManifestActionReturns = struct {
 		result1 kubernetes.Action
@@ -425,6 +567,8 @@ func (fake *FakeActionHandler) NewScaleManifestActionReturns(result1 kubernetes.
 }
 
 func (fake *FakeActionHandler) NewScaleManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
+	fake.newScaleManifestActionMutex.Lock()
+	defer fake.newScaleManifestActionMutex.Unlock()
 	fake.NewScaleManifestActionStub = nil
 	if fake.newScaleManifestActionReturnsOnCall == nil {
 		fake.newScaleManifestActionReturnsOnCall = make(map[int]struct {
@@ -436,73 +580,25 @@ func (fake *FakeActionHandler) NewScaleManifestActionReturnsOnCall(i int, result
 	}{result1}
 }
 
-func (fake *FakeActionHandler) NewPatchManifestAction(arg1 kubernetes.ActionConfig) kubernetes.Action {
-	fake.newPatchManifestActionMutex.Lock()
-	ret, specificReturn := fake.newPatchManifestActionReturnsOnCall[len(fake.newPatchManifestActionArgsForCall)]
-	fake.newPatchManifestActionArgsForCall = append(fake.newPatchManifestActionArgsForCall, struct {
-		arg1 kubernetes.ActionConfig
-	}{arg1})
-	fake.recordInvocation("NewPatchManifestAction", []interface{}{arg1})
-	fake.newPatchManifestActionMutex.Unlock()
-	if fake.NewPatchManifestActionStub != nil {
-		return fake.NewPatchManifestActionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.newPatchManifestActionReturns.result1
-}
-
-func (fake *FakeActionHandler) NewPatchManifestActionCallCount() int {
-	fake.newPatchManifestActionMutex.RLock()
-	defer fake.newPatchManifestActionMutex.RUnlock()
-	return len(fake.newPatchManifestActionArgsForCall)
-}
-
-func (fake *FakeActionHandler) NewPatchManifestActionArgsForCall(i int) kubernetes.ActionConfig {
-	fake.newPatchManifestActionMutex.RLock()
-	defer fake.newPatchManifestActionMutex.RUnlock()
-	return fake.newPatchManifestActionArgsForCall[i].arg1
-}
-
-func (fake *FakeActionHandler) NewPatchManifestActionReturns(result1 kubernetes.Action) {
-	fake.NewPatchManifestActionStub = nil
-	fake.newPatchManifestActionReturns = struct {
-		result1 kubernetes.Action
-	}{result1}
-}
-
-func (fake *FakeActionHandler) NewPatchManifestActionReturnsOnCall(i int, result1 kubernetes.Action) {
-	fake.NewPatchManifestActionStub = nil
-	if fake.newPatchManifestActionReturnsOnCall == nil {
-		fake.newPatchManifestActionReturnsOnCall = make(map[int]struct {
-			result1 kubernetes.Action
-		})
-	}
-	fake.newPatchManifestActionReturnsOnCall[i] = struct {
-		result1 kubernetes.Action
-	}{result1}
-}
-
 func (fake *FakeActionHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.newCleanupArtifactsActionMutex.RLock()
 	defer fake.newCleanupArtifactsActionMutex.RUnlock()
-	fake.newDeployManifestActionMutex.RLock()
-	defer fake.newDeployManifestActionMutex.RUnlock()
 	fake.newDeleteManifestActionMutex.RLock()
 	defer fake.newDeleteManifestActionMutex.RUnlock()
-	fake.newRollingRestartActionMutex.RLock()
-	defer fake.newRollingRestartActionMutex.RUnlock()
+	fake.newDeployManifestActionMutex.RLock()
+	defer fake.newDeployManifestActionMutex.RUnlock()
+	fake.newPatchManifestActionMutex.RLock()
+	defer fake.newPatchManifestActionMutex.RUnlock()
 	fake.newRollbackActionMutex.RLock()
 	defer fake.newRollbackActionMutex.RUnlock()
+	fake.newRollingRestartActionMutex.RLock()
+	defer fake.newRollingRestartActionMutex.RUnlock()
 	fake.newRunJobActionMutex.RLock()
 	defer fake.newRunJobActionMutex.RUnlock()
 	fake.newScaleManifestActionMutex.RLock()
 	defer fake.newScaleManifestActionMutex.RUnlock()
-	fake.newPatchManifestActionMutex.RLock()
-	defer fake.newPatchManifestActionMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -27,7 +27,7 @@ func Initialize(r *gin.Engine) {
 		// @PreAuthorize("#restricted ? @fiatPermissionEvaluator.storeWholePermission() : true")
 		// @PostFilter("#restricted ? hasPermission(filterObject.name, 'APPLICATION', 'READ') : true")
 		// middleware.authApplication()
-		api.GET("/applications", core.ListApplications)
+		api.GET("/applications", middleware.PostFilterAuthorizedApplications("READ"), core.ListApplications)
 
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java#L39
 		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -24,39 +24,38 @@ func Initialize(r *gin.Engine) {
 		// Applications API controller.
 		//
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ApplicationsController.groovy#L38
-		// @PreAuthorize("#restricted ? @fiatPermissionEvaluator.storeWholePermission() : true")
-		// @PostFilter("#restricted ? hasPermission(filterObject.name, 'APPLICATION', 'READ') : true")
-		// middleware.authApplication()
+		// @PreAuthorize("#restricted ? @fiatPermissionEvaluator.storeWholePermission() : true") -- story created
+		// @PostFilter("#restricted ? hasPermission(filterObject.name, 'APPLICATION', 'READ') : true") -- done
 		api.GET("/applications", middleware.PostFilterAuthorizedApplications("READ"), core.ListApplications)
 
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupManagerController.java#L39
-		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
-		// @PostFilter("hasPermission(filterObject.account, 'ACCOUNT', 'READ')")
+		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')") --- done
+		// @PostFilter("hasPermission(filterObject.account, 'ACCOUNT', 'READ')") -- story created
 		api.GET("/applications/:application/serverGroupManagers", middleware.AuthApplication("READ"), core.ListServerGroupManagers)
 
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy#L172
-		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
-		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)")
+		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')") -- done
+		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)") -- story created
 		api.GET("/applications/:application/serverGroups", middleware.AuthApplication("READ"), core.ListServerGroups)
 
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ServerGroupController.groovy#L75
-		// @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
-		// @PostAuthorize("hasPermission(returnObject?.moniker?.app, 'APPLICATION', 'READ')")
+		// @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')") -- done
+		// @PostAuthorize("hasPermission(returnObject?.moniker?.app, 'APPLICATION', 'READ')") -- create story
 		// textPayload: "Headers: map[Accept:[application/json] Accept-Encoding:[gzip] Connection:[Keep-Alive] User-Agent:[okhttp/3.14.9] X-Spinnaker-Accounts:[gke_github-replication-sandbox_us-east1_sandbox-us-east1-agent-dev,gke_github-replication-sandbox_us-east1_sandbox-us-east1-dev,gke_github-replication-sandbox_us-central1-c_prom-test] X-Spinnaker-Application:[smoketests] X-Spinnaker-User:[me@me.com]]"
 		api.GET("/applications/:application/serverGroups/:account/:location/:name", middleware.AuthAccount("READ"), core.GetServerGroup)
 
 		// https: //github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/LoadBalancerController.groovy#L42
-		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
-		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)")
+		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')") -- done
+		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)") --- story created
 		api.GET("/applications/:application/loadBalancers", middleware.AuthApplication("READ"), core.ListLoadBalancers)
 
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy#L44
-		// @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission() and hasPermission(#application, 'APPLICATION', 'READ')")
-		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)")
+		// @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission() -- story created and hasPermission(#application, 'APPLICATION', 'READ')") -- done
+		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)") -- story created
 		api.GET("/applications/:application/clusters", middleware.AuthApplication("READ"), core.ListClusters)
 
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/JobController.groovy#L35
-		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ') and hasPermission(#account, 'ACCOUNT', 'READ')")
+		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ') -- done and hasPermission(#account, 'ACCOUNT', 'READ')") -- done
 		// @ApiOperation(value = "Collect a JobStatus", notes = "Collects the output of the job.")
 		api.GET("/applications/:application/jobs/:account/:location/:name", middleware.AuthApplication("READ"), middleware.AuthAccount("READ"), core.GetJob)
 
@@ -73,13 +72,13 @@ func Initialize(r *gin.Engine) {
 		// Generic search endpoint.
 		//
 		// https://github.com/spinnaker/clouddriver/blob/0524d08f6bcf775c469a0576a79b2679b5653325/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/SearchController.groovy#L55
-		// @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
+		// @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()") -- story created
 		api.GET("/search", core.Search)
 
 		// Not implemented.
 		//
-		// @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
-		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)")
+		// @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()") -- story created
+		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)") -- story created
 		api.GET("/securityGroups", core.ListSecurityGroups)
 
 		// Artifacts API controller.

--- a/pkg/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
+++ b/pkg/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
@@ -9,10 +9,15 @@ import (
 )
 
 type FakeCacheRoundTripper struct {
-	RoundTripStub        func(req *http.Request) (*http.Response, error)
+	CancelRequestStub        func(*http.Request)
+	cancelRequestMutex       sync.RWMutex
+	cancelRequestArgsForCall []struct {
+		arg1 *http.Request
+	}
+	RoundTripStub        func(*http.Request) (*http.Response, error)
 	roundTripMutex       sync.RWMutex
 	roundTripArgsForCall []struct {
-		req *http.Request
+		arg1 *http.Request
 	}
 	roundTripReturns struct {
 		result1 *http.Response
@@ -22,30 +27,57 @@ type FakeCacheRoundTripper struct {
 		result1 *http.Response
 		result2 error
 	}
-	CancelRequestStub        func(req *http.Request)
-	cancelRequestMutex       sync.RWMutex
-	cancelRequestArgsForCall []struct {
-		req *http.Request
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCacheRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (fake *FakeCacheRoundTripper) CancelRequest(arg1 *http.Request) {
+	fake.cancelRequestMutex.Lock()
+	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
+		arg1 *http.Request
+	}{arg1})
+	fake.recordInvocation("CancelRequest", []interface{}{arg1})
+	fake.cancelRequestMutex.Unlock()
+	if fake.CancelRequestStub != nil {
+		fake.CancelRequestStub(arg1)
+	}
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestCallCount() int {
+	fake.cancelRequestMutex.RLock()
+	defer fake.cancelRequestMutex.RUnlock()
+	return len(fake.cancelRequestArgsForCall)
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestCalls(stub func(*http.Request)) {
+	fake.cancelRequestMutex.Lock()
+	defer fake.cancelRequestMutex.Unlock()
+	fake.CancelRequestStub = stub
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestArgsForCall(i int) *http.Request {
+	fake.cancelRequestMutex.RLock()
+	defer fake.cancelRequestMutex.RUnlock()
+	argsForCall := fake.cancelRequestArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCacheRoundTripper) RoundTrip(arg1 *http.Request) (*http.Response, error) {
 	fake.roundTripMutex.Lock()
 	ret, specificReturn := fake.roundTripReturnsOnCall[len(fake.roundTripArgsForCall)]
 	fake.roundTripArgsForCall = append(fake.roundTripArgsForCall, struct {
-		req *http.Request
-	}{req})
-	fake.recordInvocation("RoundTrip", []interface{}{req})
+		arg1 *http.Request
+	}{arg1})
+	fake.recordInvocation("RoundTrip", []interface{}{arg1})
 	fake.roundTripMutex.Unlock()
 	if fake.RoundTripStub != nil {
-		return fake.RoundTripStub(req)
+		return fake.RoundTripStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.roundTripReturns.result1, fake.roundTripReturns.result2
+	fakeReturns := fake.roundTripReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripCallCount() int {
@@ -54,13 +86,22 @@ func (fake *FakeCacheRoundTripper) RoundTripCallCount() int {
 	return len(fake.roundTripArgsForCall)
 }
 
+func (fake *FakeCacheRoundTripper) RoundTripCalls(stub func(*http.Request) (*http.Response, error)) {
+	fake.roundTripMutex.Lock()
+	defer fake.roundTripMutex.Unlock()
+	fake.RoundTripStub = stub
+}
+
 func (fake *FakeCacheRoundTripper) RoundTripArgsForCall(i int) *http.Request {
 	fake.roundTripMutex.RLock()
 	defer fake.roundTripMutex.RUnlock()
-	return fake.roundTripArgsForCall[i].req
+	argsForCall := fake.roundTripArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripReturns(result1 *http.Response, result2 error) {
+	fake.roundTripMutex.Lock()
+	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	fake.roundTripReturns = struct {
 		result1 *http.Response
@@ -69,6 +110,8 @@ func (fake *FakeCacheRoundTripper) RoundTripReturns(result1 *http.Response, resu
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripReturnsOnCall(i int, result1 *http.Response, result2 error) {
+	fake.roundTripMutex.Lock()
+	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	if fake.roundTripReturnsOnCall == nil {
 		fake.roundTripReturnsOnCall = make(map[int]struct {
@@ -82,37 +125,13 @@ func (fake *FakeCacheRoundTripper) RoundTripReturnsOnCall(i int, result1 *http.R
 	}{result1, result2}
 }
 
-func (fake *FakeCacheRoundTripper) CancelRequest(req *http.Request) {
-	fake.cancelRequestMutex.Lock()
-	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
-		req *http.Request
-	}{req})
-	fake.recordInvocation("CancelRequest", []interface{}{req})
-	fake.cancelRequestMutex.Unlock()
-	if fake.CancelRequestStub != nil {
-		fake.CancelRequestStub(req)
-	}
-}
-
-func (fake *FakeCacheRoundTripper) CancelRequestCallCount() int {
-	fake.cancelRequestMutex.RLock()
-	defer fake.cancelRequestMutex.RUnlock()
-	return len(fake.cancelRequestArgsForCall)
-}
-
-func (fake *FakeCacheRoundTripper) CancelRequestArgsForCall(i int) *http.Request {
-	fake.cancelRequestMutex.RLock()
-	defer fake.cancelRequestMutex.RUnlock()
-	return fake.cancelRequestArgsForCall[i].req
-}
-
 func (fake *FakeCacheRoundTripper) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.roundTripMutex.RLock()
-	defer fake.roundTripMutex.RUnlock()
 	fake.cancelRequestMutex.RLock()
 	defer fake.cancelRequestMutex.RUnlock()
+	fake.roundTripMutex.RLock()
+	defer fake.roundTripMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/kubernetes/kubernetesfakes/fake_client.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_client.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/billiford/go-clouddriver/pkg/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,13 +39,13 @@ type FakeClient struct {
 		result1 kubernetes.Metadata
 		result2 error
 	}
-	DeleteResourceByKindAndNameAndNamespaceStub        func(string, string, string, metav1.DeleteOptions) error
+	DeleteResourceByKindAndNameAndNamespaceStub        func(string, string, string, v1.DeleteOptions) error
 	deleteResourceByKindAndNameAndNamespaceMutex       sync.RWMutex
 	deleteResourceByKindAndNameAndNamespaceArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 metav1.DeleteOptions
+		arg4 v1.DeleteOptions
 	}
 	deleteResourceByKindAndNameAndNamespaceReturns struct {
 		result1 error
@@ -81,11 +81,11 @@ type FakeClient struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	ListByGVRStub        func(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListByGVRStub        func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)
 	listByGVRMutex       sync.RWMutex
 	listByGVRArgsForCall []struct {
 		arg1 schema.GroupVersionResource
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}
 	listByGVRReturns struct {
 		result1 *unstructured.UnstructuredList
@@ -95,11 +95,11 @@ type FakeClient struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}
-	ListResourceStub        func(string, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListResourceStub        func(string, v1.ListOptions) (*unstructured.UnstructuredList, error)
 	listResourceMutex       sync.RWMutex
 	listResourceArgsForCall []struct {
 		arg1 string
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}
 	listResourceReturns struct {
 		result1 *unstructured.UnstructuredList
@@ -164,7 +164,8 @@ func (fake *FakeClient) Apply(arg1 *unstructured.Unstructured) (kubernetes.Metad
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.applyReturns.result1, fake.applyReturns.result2
+	fakeReturns := fake.applyReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ApplyCallCount() int {
@@ -173,13 +174,22 @@ func (fake *FakeClient) ApplyCallCount() int {
 	return len(fake.applyArgsForCall)
 }
 
+func (fake *FakeClient) ApplyCalls(stub func(*unstructured.Unstructured) (kubernetes.Metadata, error)) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
+	fake.ApplyStub = stub
+}
+
 func (fake *FakeClient) ApplyArgsForCall(i int) *unstructured.Unstructured {
 	fake.applyMutex.RLock()
 	defer fake.applyMutex.RUnlock()
-	return fake.applyArgsForCall[i].arg1
+	argsForCall := fake.applyArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	fake.applyReturns = struct {
 		result1 kubernetes.Metadata
@@ -188,6 +198,8 @@ func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error)
 }
 
 func (fake *FakeClient) ApplyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	if fake.applyReturnsOnCall == nil {
 		fake.applyReturnsOnCall = make(map[int]struct {
@@ -216,7 +228,8 @@ func (fake *FakeClient) ApplyWithNamespaceOverride(arg1 *unstructured.Unstructur
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.applyWithNamespaceOverrideReturns.result1, fake.applyWithNamespaceOverrideReturns.result2
+	fakeReturns := fake.applyWithNamespaceOverrideReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
@@ -225,13 +238,22 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
 	return len(fake.applyWithNamespaceOverrideArgsForCall)
 }
 
+func (fake *FakeClient) ApplyWithNamespaceOverrideCalls(stub func(*unstructured.Unstructured, string) (kubernetes.Metadata, error)) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
+	fake.ApplyWithNamespaceOverrideStub = stub
+}
+
 func (fake *FakeClient) ApplyWithNamespaceOverrideArgsForCall(i int) (*unstructured.Unstructured, string) {
 	fake.applyWithNamespaceOverrideMutex.RLock()
 	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
-	return fake.applyWithNamespaceOverrideArgsForCall[i].arg1, fake.applyWithNamespaceOverrideArgsForCall[i].arg2
+	argsForCall := fake.applyWithNamespaceOverrideArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Metadata, result2 error) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	fake.applyWithNamespaceOverrideReturns = struct {
 		result1 kubernetes.Metadata
@@ -240,6 +262,8 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Met
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	if fake.applyWithNamespaceOverrideReturnsOnCall == nil {
 		fake.applyWithNamespaceOverrideReturnsOnCall = make(map[int]struct {
@@ -253,14 +277,14 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 k
 	}{result1, result2}
 }
 
-func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg2 string, arg3 string, arg4 metav1.DeleteOptions) error {
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg2 string, arg3 string, arg4 v1.DeleteOptions) error {
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
 	ret, specificReturn := fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall[len(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall)]
 	fake.deleteResourceByKindAndNameAndNamespaceArgsForCall = append(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 metav1.DeleteOptions
+		arg4 v1.DeleteOptions
 	}{arg1, arg2, arg3, arg4})
 	fake.recordInvocation("DeleteResourceByKindAndNameAndNamespace", []interface{}{arg1, arg2, arg3, arg4})
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
@@ -270,7 +294,8 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.deleteResourceByKindAndNameAndNamespaceReturns.result1
+	fakeReturns := fake.deleteResourceByKindAndNameAndNamespaceReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCallCount() int {
@@ -279,13 +304,22 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCallCount() int {
 	return len(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall)
 }
 
-func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceArgsForCall(i int) (string, string, string, metav1.DeleteOptions) {
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCalls(stub func(string, string, string, v1.DeleteOptions) error) {
+	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
+	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
+	fake.DeleteResourceByKindAndNameAndNamespaceStub = stub
+}
+
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceArgsForCall(i int) (string, string, string, v1.DeleteOptions) {
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.RLock()
 	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.RUnlock()
-	return fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg1, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg2, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg3, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg4
+	argsForCall := fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturns(result1 error) {
+	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
+	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
 	fake.DeleteResourceByKindAndNameAndNamespaceStub = nil
 	fake.deleteResourceByKindAndNameAndNamespaceReturns = struct {
 		result1 error
@@ -293,6 +327,8 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturns(result1 e
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturnsOnCall(i int, result1 error) {
+	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
+	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
 	fake.DeleteResourceByKindAndNameAndNamespaceStub = nil
 	if fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall == nil {
 		fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall = make(map[int]struct {
@@ -318,7 +354,8 @@ func (fake *FakeClient) GVRForKind(arg1 string) (schema.GroupVersionResource, er
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.gVRForKindReturns.result1, fake.gVRForKindReturns.result2
+	fakeReturns := fake.gVRForKindReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GVRForKindCallCount() int {
@@ -327,13 +364,22 @@ func (fake *FakeClient) GVRForKindCallCount() int {
 	return len(fake.gVRForKindArgsForCall)
 }
 
+func (fake *FakeClient) GVRForKindCalls(stub func(string) (schema.GroupVersionResource, error)) {
+	fake.gVRForKindMutex.Lock()
+	defer fake.gVRForKindMutex.Unlock()
+	fake.GVRForKindStub = stub
+}
+
 func (fake *FakeClient) GVRForKindArgsForCall(i int) string {
 	fake.gVRForKindMutex.RLock()
 	defer fake.gVRForKindMutex.RUnlock()
-	return fake.gVRForKindArgsForCall[i].arg1
+	argsForCall := fake.gVRForKindArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) GVRForKindReturns(result1 schema.GroupVersionResource, result2 error) {
+	fake.gVRForKindMutex.Lock()
+	defer fake.gVRForKindMutex.Unlock()
 	fake.GVRForKindStub = nil
 	fake.gVRForKindReturns = struct {
 		result1 schema.GroupVersionResource
@@ -342,6 +388,8 @@ func (fake *FakeClient) GVRForKindReturns(result1 schema.GroupVersionResource, r
 }
 
 func (fake *FakeClient) GVRForKindReturnsOnCall(i int, result1 schema.GroupVersionResource, result2 error) {
+	fake.gVRForKindMutex.Lock()
+	defer fake.gVRForKindMutex.Unlock()
 	fake.GVRForKindStub = nil
 	if fake.gVRForKindReturnsOnCall == nil {
 		fake.gVRForKindReturnsOnCall = make(map[int]struct {
@@ -371,7 +419,8 @@ func (fake *FakeClient) Get(arg1 string, arg2 string, arg3 string) (*unstructure
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getReturns.result1, fake.getReturns.result2
+	fakeReturns := fake.getReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GetCallCount() int {
@@ -380,13 +429,22 @@ func (fake *FakeClient) GetCallCount() int {
 	return len(fake.getArgsForCall)
 }
 
+func (fake *FakeClient) GetCalls(stub func(string, string, string) (*unstructured.Unstructured, error)) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = stub
+}
+
 func (fake *FakeClient) GetArgsForCall(i int) (string, string, string) {
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
-	return fake.getArgsForCall[i].arg1, fake.getArgsForCall[i].arg2, fake.getArgsForCall[i].arg3
+	argsForCall := fake.getArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	fake.getReturns = struct {
 		result1 *unstructured.Unstructured
@@ -395,6 +453,8 @@ func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 e
 }
 
 func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	if fake.getReturnsOnCall == nil {
 		fake.getReturnsOnCall = make(map[int]struct {
@@ -408,12 +468,12 @@ func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructur
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 v1.ListOptions) (*unstructured.UnstructuredList, error) {
 	fake.listByGVRMutex.Lock()
 	ret, specificReturn := fake.listByGVRReturnsOnCall[len(fake.listByGVRArgsForCall)]
 	fake.listByGVRArgsForCall = append(fake.listByGVRArgsForCall, struct {
 		arg1 schema.GroupVersionResource
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}{arg1, arg2})
 	fake.recordInvocation("ListByGVR", []interface{}{arg1, arg2})
 	fake.listByGVRMutex.Unlock()
@@ -423,7 +483,8 @@ func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 metav1.
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listByGVRReturns.result1, fake.listByGVRReturns.result2
+	fakeReturns := fake.listByGVRReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListByGVRCallCount() int {
@@ -432,13 +493,22 @@ func (fake *FakeClient) ListByGVRCallCount() int {
 	return len(fake.listByGVRArgsForCall)
 }
 
-func (fake *FakeClient) ListByGVRArgsForCall(i int) (schema.GroupVersionResource, metav1.ListOptions) {
+func (fake *FakeClient) ListByGVRCalls(stub func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
+	fake.listByGVRMutex.Lock()
+	defer fake.listByGVRMutex.Unlock()
+	fake.ListByGVRStub = stub
+}
+
+func (fake *FakeClient) ListByGVRArgsForCall(i int) (schema.GroupVersionResource, v1.ListOptions) {
 	fake.listByGVRMutex.RLock()
 	defer fake.listByGVRMutex.RUnlock()
-	return fake.listByGVRArgsForCall[i].arg1, fake.listByGVRArgsForCall[i].arg2
+	argsForCall := fake.listByGVRArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ListByGVRReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listByGVRMutex.Lock()
+	defer fake.listByGVRMutex.Unlock()
 	fake.ListByGVRStub = nil
 	fake.listByGVRReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -447,6 +517,8 @@ func (fake *FakeClient) ListByGVRReturns(result1 *unstructured.UnstructuredList,
 }
 
 func (fake *FakeClient) ListByGVRReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listByGVRMutex.Lock()
+	defer fake.listByGVRMutex.Unlock()
 	fake.ListByGVRStub = nil
 	if fake.listByGVRReturnsOnCall == nil {
 		fake.listByGVRReturnsOnCall = make(map[int]struct {
@@ -460,12 +532,12 @@ func (fake *FakeClient) ListByGVRReturnsOnCall(i int, result1 *unstructured.Unst
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListResource(arg1 string, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (fake *FakeClient) ListResource(arg1 string, arg2 v1.ListOptions) (*unstructured.UnstructuredList, error) {
 	fake.listResourceMutex.Lock()
 	ret, specificReturn := fake.listResourceReturnsOnCall[len(fake.listResourceArgsForCall)]
 	fake.listResourceArgsForCall = append(fake.listResourceArgsForCall, struct {
 		arg1 string
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}{arg1, arg2})
 	fake.recordInvocation("ListResource", []interface{}{arg1, arg2})
 	fake.listResourceMutex.Unlock()
@@ -475,7 +547,8 @@ func (fake *FakeClient) ListResource(arg1 string, arg2 metav1.ListOptions) (*uns
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listResourceReturns.result1, fake.listResourceReturns.result2
+	fakeReturns := fake.listResourceReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListResourceCallCount() int {
@@ -484,13 +557,22 @@ func (fake *FakeClient) ListResourceCallCount() int {
 	return len(fake.listResourceArgsForCall)
 }
 
-func (fake *FakeClient) ListResourceArgsForCall(i int) (string, metav1.ListOptions) {
+func (fake *FakeClient) ListResourceCalls(stub func(string, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
+	fake.listResourceMutex.Lock()
+	defer fake.listResourceMutex.Unlock()
+	fake.ListResourceStub = stub
+}
+
+func (fake *FakeClient) ListResourceArgsForCall(i int) (string, v1.ListOptions) {
 	fake.listResourceMutex.RLock()
 	defer fake.listResourceMutex.RUnlock()
-	return fake.listResourceArgsForCall[i].arg1, fake.listResourceArgsForCall[i].arg2
+	argsForCall := fake.listResourceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ListResourceReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listResourceMutex.Lock()
+	defer fake.listResourceMutex.Unlock()
 	fake.ListResourceStub = nil
 	fake.listResourceReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -499,6 +581,8 @@ func (fake *FakeClient) ListResourceReturns(result1 *unstructured.UnstructuredLi
 }
 
 func (fake *FakeClient) ListResourceReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listResourceMutex.Lock()
+	defer fake.listResourceMutex.Unlock()
 	fake.ListResourceStub = nil
 	if fake.listResourceReturnsOnCall == nil {
 		fake.listResourceReturnsOnCall = make(map[int]struct {
@@ -534,7 +618,8 @@ func (fake *FakeClient) Patch(arg1 string, arg2 string, arg3 string, arg4 []byte
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.patchReturns.result1, fake.patchReturns.result2, fake.patchReturns.result3
+	fakeReturns := fake.patchReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeClient) PatchCallCount() int {
@@ -543,13 +628,22 @@ func (fake *FakeClient) PatchCallCount() int {
 	return len(fake.patchArgsForCall)
 }
 
+func (fake *FakeClient) PatchCalls(stub func(string, string, string, []byte) (kubernetes.Metadata, *unstructured.Unstructured, error)) {
+	fake.patchMutex.Lock()
+	defer fake.patchMutex.Unlock()
+	fake.PatchStub = stub
+}
+
 func (fake *FakeClient) PatchArgsForCall(i int) (string, string, string, []byte) {
 	fake.patchMutex.RLock()
 	defer fake.patchMutex.RUnlock()
-	return fake.patchArgsForCall[i].arg1, fake.patchArgsForCall[i].arg2, fake.patchArgsForCall[i].arg3, fake.patchArgsForCall[i].arg4
+	argsForCall := fake.patchArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeClient) PatchReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchMutex.Lock()
+	defer fake.patchMutex.Unlock()
 	fake.PatchStub = nil
 	fake.patchReturns = struct {
 		result1 kubernetes.Metadata
@@ -559,6 +653,8 @@ func (fake *FakeClient) PatchReturns(result1 kubernetes.Metadata, result2 *unstr
 }
 
 func (fake *FakeClient) PatchReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchMutex.Lock()
+	defer fake.patchMutex.Unlock()
 	fake.PatchStub = nil
 	if fake.patchReturnsOnCall == nil {
 		fake.patchReturnsOnCall = make(map[int]struct {
@@ -597,7 +693,8 @@ func (fake *FakeClient) PatchUsingStrategy(arg1 string, arg2 string, arg3 string
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.patchUsingStrategyReturns.result1, fake.patchUsingStrategyReturns.result2, fake.patchUsingStrategyReturns.result3
+	fakeReturns := fake.patchUsingStrategyReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeClient) PatchUsingStrategyCallCount() int {
@@ -606,13 +703,22 @@ func (fake *FakeClient) PatchUsingStrategyCallCount() int {
 	return len(fake.patchUsingStrategyArgsForCall)
 }
 
+func (fake *FakeClient) PatchUsingStrategyCalls(stub func(string, string, string, []byte, types.PatchType) (kubernetes.Metadata, *unstructured.Unstructured, error)) {
+	fake.patchUsingStrategyMutex.Lock()
+	defer fake.patchUsingStrategyMutex.Unlock()
+	fake.PatchUsingStrategyStub = stub
+}
+
 func (fake *FakeClient) PatchUsingStrategyArgsForCall(i int) (string, string, string, []byte, types.PatchType) {
 	fake.patchUsingStrategyMutex.RLock()
 	defer fake.patchUsingStrategyMutex.RUnlock()
-	return fake.patchUsingStrategyArgsForCall[i].arg1, fake.patchUsingStrategyArgsForCall[i].arg2, fake.patchUsingStrategyArgsForCall[i].arg3, fake.patchUsingStrategyArgsForCall[i].arg4, fake.patchUsingStrategyArgsForCall[i].arg5
+	argsForCall := fake.patchUsingStrategyArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeClient) PatchUsingStrategyReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchUsingStrategyMutex.Lock()
+	defer fake.patchUsingStrategyMutex.Unlock()
 	fake.PatchUsingStrategyStub = nil
 	fake.patchUsingStrategyReturns = struct {
 		result1 kubernetes.Metadata
@@ -622,6 +728,8 @@ func (fake *FakeClient) PatchUsingStrategyReturns(result1 kubernetes.Metadata, r
 }
 
 func (fake *FakeClient) PatchUsingStrategyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchUsingStrategyMutex.Lock()
+	defer fake.patchUsingStrategyMutex.Unlock()
 	fake.PatchUsingStrategyStub = nil
 	if fake.patchUsingStrategyReturnsOnCall == nil {
 		fake.patchUsingStrategyReturnsOnCall = make(map[int]struct {

--- a/pkg/kubernetes/kubernetesfakes/fake_controller.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_controller.go
@@ -10,6 +10,30 @@ import (
 )
 
 type FakeController struct {
+	AddSpinnakerAnnotationsStub        func(*unstructured.Unstructured, string) error
+	addSpinnakerAnnotationsMutex       sync.RWMutex
+	addSpinnakerAnnotationsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}
+	addSpinnakerAnnotationsReturns struct {
+		result1 error
+	}
+	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	AddSpinnakerLabelsStub        func(*unstructured.Unstructured, string) error
+	addSpinnakerLabelsMutex       sync.RWMutex
+	addSpinnakerLabelsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}
+	addSpinnakerLabelsReturns struct {
+		result1 error
+	}
+	addSpinnakerLabelsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	NewClientStub        func(*rest.Config) (kubernetes.Client, error)
 	newClientMutex       sync.RWMutex
 	newClientArgsForCall []struct {
@@ -36,32 +60,130 @@ type FakeController struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	AddSpinnakerAnnotationsStub        func(u *unstructured.Unstructured, application string) error
-	addSpinnakerAnnotationsMutex       sync.RWMutex
-	addSpinnakerAnnotationsArgsForCall []struct {
-		u           *unstructured.Unstructured
-		application string
-	}
-	addSpinnakerAnnotationsReturns struct {
-		result1 error
-	}
-	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	AddSpinnakerLabelsStub        func(u *unstructured.Unstructured, application string) error
-	addSpinnakerLabelsMutex       sync.RWMutex
-	addSpinnakerLabelsArgsForCall []struct {
-		u           *unstructured.Unstructured
-		application string
-	}
-	addSpinnakerLabelsReturns struct {
-		result1 error
-	}
-	addSpinnakerLabelsReturnsOnCall map[int]struct {
-		result1 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeController) AddSpinnakerAnnotations(arg1 *unstructured.Unstructured, arg2 string) error {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
+	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{arg1, arg2})
+	fake.addSpinnakerAnnotationsMutex.Unlock()
+	if fake.AddSpinnakerAnnotationsStub != nil {
+		return fake.AddSpinnakerAnnotationsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerAnnotationsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	return len(fake.addSpinnakerAnnotationsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsCalls(stub func(*unstructured.Unstructured, string) error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerAnnotationsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = nil
+	fake.addSpinnakerAnnotationsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = nil
+	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
+		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabels(arg1 *unstructured.Unstructured, arg2 string) error {
+	fake.addSpinnakerLabelsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
+	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerLabels", []interface{}{arg1, arg2})
+	fake.addSpinnakerLabelsMutex.Unlock()
+	if fake.AddSpinnakerLabelsStub != nil {
+		return fake.AddSpinnakerLabelsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerLabelsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	return len(fake.addSpinnakerLabelsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerLabelsCalls(stub func(*unstructured.Unstructured, string) error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerLabelsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = nil
+	fake.addSpinnakerLabelsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = nil
+	if fake.addSpinnakerLabelsReturnsOnCall == nil {
+		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, error) {
@@ -78,7 +200,8 @@ func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, err
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.newClientReturns.result1, fake.newClientReturns.result2
+	fakeReturns := fake.newClientReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeController) NewClientCallCount() int {
@@ -87,13 +210,22 @@ func (fake *FakeController) NewClientCallCount() int {
 	return len(fake.newClientArgsForCall)
 }
 
+func (fake *FakeController) NewClientCalls(stub func(*rest.Config) (kubernetes.Client, error)) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
+	fake.NewClientStub = stub
+}
+
 func (fake *FakeController) NewClientArgsForCall(i int) *rest.Config {
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
-	return fake.newClientArgsForCall[i].arg1
+	argsForCall := fake.newClientArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 error) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	fake.newClientReturns = struct {
 		result1 kubernetes.Client
@@ -102,6 +234,8 @@ func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 
 }
 
 func (fake *FakeController) NewClientReturnsOnCall(i int, result1 kubernetes.Client, result2 error) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	if fake.newClientReturnsOnCall == nil {
 		fake.newClientReturnsOnCall = make(map[int]struct {
@@ -129,7 +263,8 @@ func (fake *FakeController) ToUnstructured(arg1 map[string]interface{}) (*unstru
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.toUnstructuredReturns.result1, fake.toUnstructuredReturns.result2
+	fakeReturns := fake.toUnstructuredReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeController) ToUnstructuredCallCount() int {
@@ -138,13 +273,22 @@ func (fake *FakeController) ToUnstructuredCallCount() int {
 	return len(fake.toUnstructuredArgsForCall)
 }
 
+func (fake *FakeController) ToUnstructuredCalls(stub func(map[string]interface{}) (*unstructured.Unstructured, error)) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
+	fake.ToUnstructuredStub = stub
+}
+
 func (fake *FakeController) ToUnstructuredArgsForCall(i int) map[string]interface{} {
 	fake.toUnstructuredMutex.RLock()
 	defer fake.toUnstructuredMutex.RUnlock()
-	return fake.toUnstructuredArgsForCall[i].arg1
+	argsForCall := fake.toUnstructuredArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstructured, result2 error) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
 	fake.ToUnstructuredStub = nil
 	fake.toUnstructuredReturns = struct {
 		result1 *unstructured.Unstructured
@@ -153,6 +297,8 @@ func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstruct
 }
 
 func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
 	fake.ToUnstructuredStub = nil
 	if fake.toUnstructuredReturnsOnCall == nil {
 		fake.toUnstructuredReturnsOnCall = make(map[int]struct {
@@ -166,115 +312,17 @@ func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstruct
 	}{result1, result2}
 }
 
-func (fake *FakeController) AddSpinnakerAnnotations(u *unstructured.Unstructured, application string) error {
-	fake.addSpinnakerAnnotationsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
-	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
-		u           *unstructured.Unstructured
-		application string
-	}{u, application})
-	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{u, application})
-	fake.addSpinnakerAnnotationsMutex.Unlock()
-	if fake.AddSpinnakerAnnotationsStub != nil {
-		return fake.AddSpinnakerAnnotationsStub(u, application)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.addSpinnakerAnnotationsReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	return len(fake.addSpinnakerAnnotationsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	return fake.addSpinnakerAnnotationsArgsForCall[i].u, fake.addSpinnakerAnnotationsArgsForCall[i].application
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
-	fake.AddSpinnakerAnnotationsStub = nil
-	fake.addSpinnakerAnnotationsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerAnnotationsStub = nil
-	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
-		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabels(u *unstructured.Unstructured, application string) error {
-	fake.addSpinnakerLabelsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
-	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
-		u           *unstructured.Unstructured
-		application string
-	}{u, application})
-	fake.recordInvocation("AddSpinnakerLabels", []interface{}{u, application})
-	fake.addSpinnakerLabelsMutex.Unlock()
-	if fake.AddSpinnakerLabelsStub != nil {
-		return fake.AddSpinnakerLabelsStub(u, application)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.addSpinnakerLabelsReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	return len(fake.addSpinnakerLabelsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	return fake.addSpinnakerLabelsArgsForCall[i].u, fake.addSpinnakerLabelsArgsForCall[i].application
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
-	fake.AddSpinnakerLabelsStub = nil
-	fake.addSpinnakerLabelsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerLabelsStub = nil
-	if fake.addSpinnakerLabelsReturnsOnCall == nil {
-		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
 	fake.toUnstructuredMutex.RLock()
 	defer fake.toUnstructuredMutex.RUnlock()
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -89,6 +89,10 @@ func PostFilterAuthorizedApplications(permissions ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Next()
 
+		if len(c.Errors) > 0 {
+			return
+		}
+
 		allApps := core.Applications{}
 		allApps = c.MustGet(core.KeyAllApplications).(core.Applications)
 
@@ -110,7 +114,7 @@ func PostFilterAuthorizedApplications(permissions ...string) gin.HandlerFunc {
 			authorizedAppsMap[app.Name] = app
 		}
 
-		filteredApps := filterAuthorizedApps(authorizedAppsMap, allApps, permissions...)
+		filteredApps := FilterAuthorizedApps(authorizedAppsMap, allApps, permissions...)
 
 		c.JSON(http.StatusOK, filteredApps)
 	}
@@ -125,7 +129,7 @@ func find(slice []string, val string) bool {
 	return false
 }
 
-func filterAuthorizedApps(authorizedAppsMap map[string]fiat.Application, allApps core.Applications, permissions ...string) []core.Application {
+func FilterAuthorizedApps(authorizedAppsMap map[string]fiat.Application, allApps core.Applications, permissions ...string) []core.Application {
 	filteredApps := []core.Application{}
 	for _, app := range allApps {
 		if authorizedApp, ok := authorizedAppsMap[app.Name]; ok {

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -211,7 +211,6 @@ var _ = Describe("Auth", func() {
 
 	Describe("#FilterAuthorizedApplications", func() {
 		BeforeEach(func() {
-			c.Abort()
 			hf = PostFilterAuthorizedApplications("READ")
 			allApps = append(allApps, core.Application{
 				Name: "test-app1",
@@ -221,6 +220,10 @@ var _ = Describe("Auth", func() {
 
 		JustBeforeEach(func() {
 			hf(c)
+		})
+
+		AfterEach(func() {
+			c.Abort()
 		})
 
 		When("user is missing from header", func() {

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -2,7 +2,6 @@ package middleware_test
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -229,7 +228,7 @@ var _ = Describe("Auth", func() {
 			c.Abort()
 		})
 
-		When("There is an error attached to the context", func() {
+		When("there is an error attached to the context", func() {
 			BeforeEach(func() {
 				c.Errors = append(c.Errors, c.Error(errors.New("fake error")))
 			})
@@ -250,7 +249,7 @@ var _ = Describe("Auth", func() {
 			})
 		})
 
-		When("fiate Authorize function returns an error", func() {
+		When("fiat returns an error", func() {
 			BeforeEach(func() {
 				fakeApplication := fiat.Application{
 					Name:           testApplication,
@@ -282,7 +281,7 @@ var _ = Describe("Auth", func() {
 				filteredApps = middleware.FilterAuthorizedApps(authorizedAppsMap, allApps, "READ")
 			})
 
-			It("returns and empty list", func() {
+			It("returns an empty list", func() {
 				Expect(len(filteredApps)).To(BeZero())
 			})
 		})
@@ -298,7 +297,7 @@ var _ = Describe("Auth", func() {
 				filteredApps = middleware.FilterAuthorizedApps(authorizedAppsMap, allApps, "READ")
 			})
 
-			It("returns and empty list", func() {
+			It("returns an empty list", func() {
 				Expect(len(filteredApps)).To(BeZero())
 			})
 		})
@@ -318,7 +317,7 @@ var _ = Describe("Auth", func() {
 				filteredApps = middleware.FilterAuthorizedApps(authorizedAppsMap, allApps, "WRITE")
 			})
 
-			It("returns and empty list", func() {
+			It("returns an empty list", func() {
 				Expect(len(filteredApps)).To(BeZero())
 			})
 		})
@@ -339,8 +338,7 @@ var _ = Describe("Auth", func() {
 				filteredApps = middleware.FilterAuthorizedApps(authorizedAppsMap, allApps, "READ")
 			})
 
-			It("returns and empty list", func() {
-				fmt.Printf("filteredApps %+v", filteredApps)
+			It("returns an empty list", func() {
 				Expect(len(filteredApps)).To(Equal(1))
 			})
 		})

--- a/pkg/sql/sqlfakes/fake_client.go
+++ b/pkg/sql/sqlfakes/fake_client.go
@@ -7,34 +7,9 @@ import (
 	clouddriver "github.com/billiford/go-clouddriver/pkg"
 	"github.com/billiford/go-clouddriver/pkg/kubernetes"
 	"github.com/billiford/go-clouddriver/pkg/sql"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 type FakeClient struct {
-	DeleteKubernetesProviderStub        func(string) error
-	deleteKubernetesProviderMutex       sync.RWMutex
-	deleteKubernetesProviderArgsForCall []struct {
-		arg1 string
-	}
-	deleteKubernetesProviderReturns struct {
-		result1 error
-	}
-	deleteKubernetesProviderReturnsOnCall map[int]struct {
-		result1 error
-	}
-	GetKubernetesProviderStub        func(string) (kubernetes.Provider, error)
-	getKubernetesProviderMutex       sync.RWMutex
-	getKubernetesProviderArgsForCall []struct {
-		arg1 string
-	}
-	getKubernetesProviderReturns struct {
-		result1 kubernetes.Provider
-		result2 error
-	}
-	getKubernetesProviderReturnsOnCall map[int]struct {
-		result1 kubernetes.Provider
-		result2 error
-	}
 	CreateKubernetesProviderStub        func(kubernetes.Provider) error
 	createKubernetesProviderMutex       sync.RWMutex
 	createKubernetesProviderArgsForCall []struct {
@@ -79,6 +54,30 @@ type FakeClient struct {
 	createWritePermissionReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteKubernetesProviderStub        func(string) error
+	deleteKubernetesProviderMutex       sync.RWMutex
+	deleteKubernetesProviderArgsForCall []struct {
+		arg1 string
+	}
+	deleteKubernetesProviderReturns struct {
+		result1 error
+	}
+	deleteKubernetesProviderReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GetKubernetesProviderStub        func(string) (kubernetes.Provider, error)
+	getKubernetesProviderMutex       sync.RWMutex
+	getKubernetesProviderArgsForCall []struct {
+		arg1 string
+	}
+	getKubernetesProviderReturns struct {
+		result1 kubernetes.Provider
+		result2 error
+	}
+	getKubernetesProviderReturnsOnCall map[int]struct {
+		result1 kubernetes.Provider
+		result2 error
+	}
 	ListKubernetesAccountsBySpinnakerAppStub        func(string) ([]string, error)
 	listKubernetesAccountsBySpinnakerAppMutex       sync.RWMutex
 	listKubernetesAccountsBySpinnakerAppArgsForCall []struct {
@@ -107,8 +106,9 @@ type FakeClient struct {
 	}
 	ListKubernetesProvidersStub        func() ([]kubernetes.Provider, error)
 	listKubernetesProvidersMutex       sync.RWMutex
-	listKubernetesProvidersArgsForCall []struct{}
-	listKubernetesProvidersReturns     struct {
+	listKubernetesProvidersArgsForCall []struct {
+	}
+	listKubernetesProvidersReturns struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
@@ -118,13 +118,29 @@ type FakeClient struct {
 	}
 	ListKubernetesProvidersAndPermissionsStub        func() ([]kubernetes.Provider, error)
 	listKubernetesProvidersAndPermissionsMutex       sync.RWMutex
-	listKubernetesProvidersAndPermissionsArgsForCall []struct{}
-	listKubernetesProvidersAndPermissionsReturns     struct {
+	listKubernetesProvidersAndPermissionsArgsForCall []struct {
+	}
+	listKubernetesProvidersAndPermissionsReturns struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
 	listKubernetesProvidersAndPermissionsReturnsOnCall map[int]struct {
 		result1 []kubernetes.Provider
+		result2 error
+	}
+	ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub        func(string, string, string) ([]string, error)
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex       sync.RWMutex
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns struct {
+		result1 []string
+		result2 error
+	}
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall map[int]struct {
+		result1 []string
 		result2 error
 	}
 	ListKubernetesResourcesByFieldsStub        func(...string) ([]kubernetes.Resource, error)
@@ -151,21 +167,6 @@ type FakeClient struct {
 	}
 	listKubernetesResourcesByTaskIDReturnsOnCall map[int]struct {
 		result1 []kubernetes.Resource
-		result2 error
-	}
-	ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub        func(string, string, string) ([]string, error)
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex       sync.RWMutex
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall []struct {
-		arg1 string
-		arg2 string
-		arg3 string
-	}
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns struct {
-		result1 []string
-		result2 error
-	}
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall map[int]struct {
-		result1 []string
 		result2 error
 	}
 	ListReadGroupsByAccountNameStub        func(string) ([]string, error)
@@ -198,105 +199,6 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) DeleteKubernetesProvider(arg1 string) error {
-	fake.deleteKubernetesProviderMutex.Lock()
-	ret, specificReturn := fake.deleteKubernetesProviderReturnsOnCall[len(fake.deleteKubernetesProviderArgsForCall)]
-	fake.deleteKubernetesProviderArgsForCall = append(fake.deleteKubernetesProviderArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("DeleteKubernetesProvider", []interface{}{arg1})
-	fake.deleteKubernetesProviderMutex.Unlock()
-	if fake.DeleteKubernetesProviderStub != nil {
-		return fake.DeleteKubernetesProviderStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.deleteKubernetesProviderReturns.result1
-}
-
-func (fake *FakeClient) DeleteKubernetesProviderCallCount() int {
-	fake.deleteKubernetesProviderMutex.RLock()
-	defer fake.deleteKubernetesProviderMutex.RUnlock()
-	return len(fake.deleteKubernetesProviderArgsForCall)
-}
-
-func (fake *FakeClient) DeleteKubernetesProviderArgsForCall(i int) string {
-	fake.deleteKubernetesProviderMutex.RLock()
-	defer fake.deleteKubernetesProviderMutex.RUnlock()
-	return fake.deleteKubernetesProviderArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) DeleteKubernetesProviderReturns(result1 error) {
-	fake.DeleteKubernetesProviderStub = nil
-	fake.deleteKubernetesProviderReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) DeleteKubernetesProviderReturnsOnCall(i int, result1 error) {
-	fake.DeleteKubernetesProviderStub = nil
-	if fake.deleteKubernetesProviderReturnsOnCall == nil {
-		fake.deleteKubernetesProviderReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.deleteKubernetesProviderReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) GetKubernetesProvider(arg1 string) (kubernetes.Provider, error) {
-	fake.getKubernetesProviderMutex.Lock()
-	ret, specificReturn := fake.getKubernetesProviderReturnsOnCall[len(fake.getKubernetesProviderArgsForCall)]
-	fake.getKubernetesProviderArgsForCall = append(fake.getKubernetesProviderArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("GetKubernetesProvider", []interface{}{arg1})
-	fake.getKubernetesProviderMutex.Unlock()
-	if fake.GetKubernetesProviderStub != nil {
-		return fake.GetKubernetesProviderStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.getKubernetesProviderReturns.result1, fake.getKubernetesProviderReturns.result2
-}
-
-func (fake *FakeClient) GetKubernetesProviderCallCount() int {
-	fake.getKubernetesProviderMutex.RLock()
-	defer fake.getKubernetesProviderMutex.RUnlock()
-	return len(fake.getKubernetesProviderArgsForCall)
-}
-
-func (fake *FakeClient) GetKubernetesProviderArgsForCall(i int) string {
-	fake.getKubernetesProviderMutex.RLock()
-	defer fake.getKubernetesProviderMutex.RUnlock()
-	return fake.getKubernetesProviderArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider, result2 error) {
-	fake.GetKubernetesProviderStub = nil
-	fake.getKubernetesProviderReturns = struct {
-		result1 kubernetes.Provider
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetKubernetesProviderReturnsOnCall(i int, result1 kubernetes.Provider, result2 error) {
-	fake.GetKubernetesProviderStub = nil
-	if fake.getKubernetesProviderReturnsOnCall == nil {
-		fake.getKubernetesProviderReturnsOnCall = make(map[int]struct {
-			result1 kubernetes.Provider
-			result2 error
-		})
-	}
-	fake.getKubernetesProviderReturnsOnCall[i] = struct {
-		result1 kubernetes.Provider
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeClient) CreateKubernetesProvider(arg1 kubernetes.Provider) error {
 	fake.createKubernetesProviderMutex.Lock()
 	ret, specificReturn := fake.createKubernetesProviderReturnsOnCall[len(fake.createKubernetesProviderArgsForCall)]
@@ -311,7 +213,8 @@ func (fake *FakeClient) CreateKubernetesProvider(arg1 kubernetes.Provider) error
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createKubernetesProviderReturns.result1
+	fakeReturns := fake.createKubernetesProviderReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
@@ -320,13 +223,22 @@ func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
 	return len(fake.createKubernetesProviderArgsForCall)
 }
 
+func (fake *FakeClient) CreateKubernetesProviderCalls(stub func(kubernetes.Provider) error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
+	fake.CreateKubernetesProviderStub = stub
+}
+
 func (fake *FakeClient) CreateKubernetesProviderArgsForCall(i int) kubernetes.Provider {
 	fake.createKubernetesProviderMutex.RLock()
 	defer fake.createKubernetesProviderMutex.RUnlock()
-	return fake.createKubernetesProviderArgsForCall[i].arg1
+	argsForCall := fake.createKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	fake.createKubernetesProviderReturns = struct {
 		result1 error
@@ -334,6 +246,8 @@ func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturnsOnCall(i int, result1 error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	if fake.createKubernetesProviderReturnsOnCall == nil {
 		fake.createKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -359,7 +273,8 @@ func (fake *FakeClient) CreateKubernetesResource(arg1 kubernetes.Resource) error
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createKubernetesResourceReturns.result1
+	fakeReturns := fake.createKubernetesResourceReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
@@ -368,13 +283,22 @@ func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
 	return len(fake.createKubernetesResourceArgsForCall)
 }
 
+func (fake *FakeClient) CreateKubernetesResourceCalls(stub func(kubernetes.Resource) error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
+	fake.CreateKubernetesResourceStub = stub
+}
+
 func (fake *FakeClient) CreateKubernetesResourceArgsForCall(i int) kubernetes.Resource {
 	fake.createKubernetesResourceMutex.RLock()
 	defer fake.createKubernetesResourceMutex.RUnlock()
-	return fake.createKubernetesResourceArgsForCall[i].arg1
+	argsForCall := fake.createKubernetesResourceArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	fake.createKubernetesResourceReturns = struct {
 		result1 error
@@ -382,6 +306,8 @@ func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturnsOnCall(i int, result1 error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	if fake.createKubernetesResourceReturnsOnCall == nil {
 		fake.createKubernetesResourceReturnsOnCall = make(map[int]struct {
@@ -407,7 +333,8 @@ func (fake *FakeClient) CreateReadPermission(arg1 clouddriver.ReadPermission) er
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createReadPermissionReturns.result1
+	fakeReturns := fake.createReadPermissionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateReadPermissionCallCount() int {
@@ -416,13 +343,22 @@ func (fake *FakeClient) CreateReadPermissionCallCount() int {
 	return len(fake.createReadPermissionArgsForCall)
 }
 
+func (fake *FakeClient) CreateReadPermissionCalls(stub func(clouddriver.ReadPermission) error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
+	fake.CreateReadPermissionStub = stub
+}
+
 func (fake *FakeClient) CreateReadPermissionArgsForCall(i int) clouddriver.ReadPermission {
 	fake.createReadPermissionMutex.RLock()
 	defer fake.createReadPermissionMutex.RUnlock()
-	return fake.createReadPermissionArgsForCall[i].arg1
+	argsForCall := fake.createReadPermissionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	fake.createReadPermissionReturns = struct {
 		result1 error
@@ -430,6 +366,8 @@ func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateReadPermissionReturnsOnCall(i int, result1 error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	if fake.createReadPermissionReturnsOnCall == nil {
 		fake.createReadPermissionReturnsOnCall = make(map[int]struct {
@@ -455,7 +393,8 @@ func (fake *FakeClient) CreateWritePermission(arg1 clouddriver.WritePermission) 
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createWritePermissionReturns.result1
+	fakeReturns := fake.createWritePermissionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateWritePermissionCallCount() int {
@@ -464,13 +403,22 @@ func (fake *FakeClient) CreateWritePermissionCallCount() int {
 	return len(fake.createWritePermissionArgsForCall)
 }
 
+func (fake *FakeClient) CreateWritePermissionCalls(stub func(clouddriver.WritePermission) error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
+	fake.CreateWritePermissionStub = stub
+}
+
 func (fake *FakeClient) CreateWritePermissionArgsForCall(i int) clouddriver.WritePermission {
 	fake.createWritePermissionMutex.RLock()
 	defer fake.createWritePermissionMutex.RUnlock()
-	return fake.createWritePermissionArgsForCall[i].arg1
+	argsForCall := fake.createWritePermissionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	fake.createWritePermissionReturns = struct {
 		result1 error
@@ -478,6 +426,8 @@ func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	if fake.createWritePermissionReturnsOnCall == nil {
 		fake.createWritePermissionReturnsOnCall = make(map[int]struct {
@@ -487,6 +437,129 @@ func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error)
 	fake.createWritePermissionReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeClient) DeleteKubernetesProvider(arg1 string) error {
+	fake.deleteKubernetesProviderMutex.Lock()
+	ret, specificReturn := fake.deleteKubernetesProviderReturnsOnCall[len(fake.deleteKubernetesProviderArgsForCall)]
+	fake.deleteKubernetesProviderArgsForCall = append(fake.deleteKubernetesProviderArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("DeleteKubernetesProvider", []interface{}{arg1})
+	fake.deleteKubernetesProviderMutex.Unlock()
+	if fake.DeleteKubernetesProviderStub != nil {
+		return fake.DeleteKubernetesProviderStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteKubernetesProviderReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DeleteKubernetesProviderCallCount() int {
+	fake.deleteKubernetesProviderMutex.RLock()
+	defer fake.deleteKubernetesProviderMutex.RUnlock()
+	return len(fake.deleteKubernetesProviderArgsForCall)
+}
+
+func (fake *FakeClient) DeleteKubernetesProviderCalls(stub func(string) error) {
+	fake.deleteKubernetesProviderMutex.Lock()
+	defer fake.deleteKubernetesProviderMutex.Unlock()
+	fake.DeleteKubernetesProviderStub = stub
+}
+
+func (fake *FakeClient) DeleteKubernetesProviderArgsForCall(i int) string {
+	fake.deleteKubernetesProviderMutex.RLock()
+	defer fake.deleteKubernetesProviderMutex.RUnlock()
+	argsForCall := fake.deleteKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) DeleteKubernetesProviderReturns(result1 error) {
+	fake.deleteKubernetesProviderMutex.Lock()
+	defer fake.deleteKubernetesProviderMutex.Unlock()
+	fake.DeleteKubernetesProviderStub = nil
+	fake.deleteKubernetesProviderReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeleteKubernetesProviderReturnsOnCall(i int, result1 error) {
+	fake.deleteKubernetesProviderMutex.Lock()
+	defer fake.deleteKubernetesProviderMutex.Unlock()
+	fake.DeleteKubernetesProviderStub = nil
+	if fake.deleteKubernetesProviderReturnsOnCall == nil {
+		fake.deleteKubernetesProviderReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteKubernetesProviderReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) GetKubernetesProvider(arg1 string) (kubernetes.Provider, error) {
+	fake.getKubernetesProviderMutex.Lock()
+	ret, specificReturn := fake.getKubernetesProviderReturnsOnCall[len(fake.getKubernetesProviderArgsForCall)]
+	fake.getKubernetesProviderArgsForCall = append(fake.getKubernetesProviderArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetKubernetesProvider", []interface{}{arg1})
+	fake.getKubernetesProviderMutex.Unlock()
+	if fake.GetKubernetesProviderStub != nil {
+		return fake.GetKubernetesProviderStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getKubernetesProviderReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetKubernetesProviderCallCount() int {
+	fake.getKubernetesProviderMutex.RLock()
+	defer fake.getKubernetesProviderMutex.RUnlock()
+	return len(fake.getKubernetesProviderArgsForCall)
+}
+
+func (fake *FakeClient) GetKubernetesProviderCalls(stub func(string) (kubernetes.Provider, error)) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
+	fake.GetKubernetesProviderStub = stub
+}
+
+func (fake *FakeClient) GetKubernetesProviderArgsForCall(i int) string {
+	fake.getKubernetesProviderMutex.RLock()
+	defer fake.getKubernetesProviderMutex.RUnlock()
+	argsForCall := fake.getKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
+	fake.GetKubernetesProviderStub = nil
+	fake.getKubernetesProviderReturns = struct {
+		result1 kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetKubernetesProviderReturnsOnCall(i int, result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
+	fake.GetKubernetesProviderStub = nil
+	if fake.getKubernetesProviderReturnsOnCall == nil {
+		fake.getKubernetesProviderReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Provider
+			result2 error
+		})
+	}
+	fake.getKubernetesProviderReturnsOnCall[i] = struct {
+		result1 kubernetes.Provider
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]string, error) {
@@ -503,7 +576,8 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]str
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesAccountsBySpinnakerAppReturns.result1, fake.listKubernetesAccountsBySpinnakerAppReturns.result2
+	fakeReturns := fake.listKubernetesAccountsBySpinnakerAppReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
@@ -512,13 +586,22 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
 	return len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCalls(stub func(string) ([]string, error)) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
+	fake.ListKubernetesAccountsBySpinnakerAppStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppArgsForCall(i int) string {
 	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
 	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
-	return fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []string, result2 error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
 	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
 	fake.listKubernetesAccountsBySpinnakerAppReturns = struct {
 		result1 []string
@@ -527,6 +610,8 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []st
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
 	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
 	if fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall == nil {
 		fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall = make(map[int]struct {
@@ -554,7 +639,8 @@ func (fake *FakeClient) ListKubernetesClustersByApplication(arg1 string) ([]kube
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesClustersByApplicationReturns.result1, fake.listKubernetesClustersByApplicationReturns.result2
+	fakeReturns := fake.listKubernetesClustersByApplicationReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationCallCount() int {
@@ -563,13 +649,22 @@ func (fake *FakeClient) ListKubernetesClustersByApplicationCallCount() int {
 	return len(fake.listKubernetesClustersByApplicationArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesClustersByApplicationCalls(stub func(string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesClustersByApplicationMutex.Lock()
+	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
+	fake.ListKubernetesClustersByApplicationStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesClustersByApplicationArgsForCall(i int) string {
 	fake.listKubernetesClustersByApplicationMutex.RLock()
 	defer fake.listKubernetesClustersByApplicationMutex.RUnlock()
-	return fake.listKubernetesClustersByApplicationArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesClustersByApplicationArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesClustersByApplicationMutex.Lock()
+	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
 	fake.ListKubernetesClustersByApplicationStub = nil
 	fake.listKubernetesClustersByApplicationReturns = struct {
 		result1 []kubernetes.Resource
@@ -578,6 +673,8 @@ func (fake *FakeClient) ListKubernetesClustersByApplicationReturns(result1 []kub
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesClustersByApplicationMutex.Lock()
+	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
 	fake.ListKubernetesClustersByApplicationStub = nil
 	if fake.listKubernetesClustersByApplicationReturnsOnCall == nil {
 		fake.listKubernetesClustersByApplicationReturnsOnCall = make(map[int]struct {
@@ -594,7 +691,8 @@ func (fake *FakeClient) ListKubernetesClustersByApplicationReturnsOnCall(i int, 
 func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error) {
 	fake.listKubernetesProvidersMutex.Lock()
 	ret, specificReturn := fake.listKubernetesProvidersReturnsOnCall[len(fake.listKubernetesProvidersArgsForCall)]
-	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct{}{})
+	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct {
+	}{})
 	fake.recordInvocation("ListKubernetesProviders", []interface{}{})
 	fake.listKubernetesProvidersMutex.Unlock()
 	if fake.ListKubernetesProvidersStub != nil {
@@ -603,7 +701,8 @@ func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error)
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesProvidersReturns.result1, fake.listKubernetesProvidersReturns.result2
+	fakeReturns := fake.listKubernetesProvidersReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
@@ -612,7 +711,15 @@ func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
 	return len(fake.listKubernetesProvidersArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesProvidersCalls(stub func() ([]kubernetes.Provider, error)) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
+	fake.ListKubernetesProvidersStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	fake.listKubernetesProvidersReturns = struct {
 		result1 []kubernetes.Provider
@@ -621,6 +728,8 @@ func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Prov
 }
 
 func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	if fake.listKubernetesProvidersReturnsOnCall == nil {
 		fake.listKubernetesProvidersReturnsOnCall = make(map[int]struct {
@@ -637,7 +746,8 @@ func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []ku
 func (fake *FakeClient) ListKubernetesProvidersAndPermissions() ([]kubernetes.Provider, error) {
 	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
 	ret, specificReturn := fake.listKubernetesProvidersAndPermissionsReturnsOnCall[len(fake.listKubernetesProvidersAndPermissionsArgsForCall)]
-	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct{}{})
+	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct {
+	}{})
 	fake.recordInvocation("ListKubernetesProvidersAndPermissions", []interface{}{})
 	fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	if fake.ListKubernetesProvidersAndPermissionsStub != nil {
@@ -646,7 +756,8 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissions() ([]kubernetes.Pr
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesProvidersAndPermissionsReturns.result1, fake.listKubernetesProvidersAndPermissionsReturns.result2
+	fakeReturns := fake.listKubernetesProvidersAndPermissionsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCallCount() int {
@@ -655,7 +766,15 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCallCount() int {
 	return len(fake.listKubernetesProvidersAndPermissionsArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCalls(stub func() ([]kubernetes.Provider, error)) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
+	fake.ListKubernetesProvidersAndPermissionsStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturns(result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	fake.ListKubernetesProvidersAndPermissionsStub = nil
 	fake.listKubernetesProvidersAndPermissionsReturns = struct {
 		result1 []kubernetes.Provider
@@ -664,6 +783,8 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturns(result1 []k
 }
 
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	fake.ListKubernetesProvidersAndPermissionsStub = nil
 	if fake.listKubernetesProvidersAndPermissionsReturnsOnCall == nil {
 		fake.listKubernetesProvidersAndPermissionsReturnsOnCall = make(map[int]struct {
@@ -673,6 +794,71 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturnsOnCall(i int
 	}
 	fake.listKubernetesProvidersAndPermissionsReturnsOnCall[i] = struct {
 		result1 []kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(arg1 string, arg2 string, arg3 string) ([]string, error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	ret, specificReturn := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)]
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall = append(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	if fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub != nil {
+		return fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCallCount() int {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	return len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCalls(stub func(string, string, string) ([]string, error)) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = stub
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall(i int) (string, string, string) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	argsForCall := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(result1 []string, result2 error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	if fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall == nil {
+		fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[i] = struct {
+		result1 []string
 		result2 error
 	}{result1, result2}
 }
@@ -691,7 +877,8 @@ func (fake *FakeClient) ListKubernetesResourcesByFields(arg1 ...string) ([]kuber
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesResourcesByFieldsReturns.result1, fake.listKubernetesResourcesByFieldsReturns.result2
+	fakeReturns := fake.listKubernetesResourcesByFieldsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
@@ -700,13 +887,22 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
 	return len(fake.listKubernetesResourcesByFieldsArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesResourcesByFieldsCalls(stub func(...string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
+	fake.ListKubernetesResourcesByFieldsStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesResourcesByFieldsArgsForCall(i int) []string {
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
-	return fake.listKubernetesResourcesByFieldsArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesResourcesByFieldsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	fake.listKubernetesResourcesByFieldsReturns = struct {
 		result1 []kubernetes.Resource
@@ -715,6 +911,8 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	if fake.listKubernetesResourcesByFieldsReturnsOnCall == nil {
 		fake.listKubernetesResourcesByFieldsReturnsOnCall = make(map[int]struct {
@@ -742,7 +940,8 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskID(arg1 string) ([]kubernet
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesResourcesByTaskIDReturns.result1, fake.listKubernetesResourcesByTaskIDReturns.result2
+	fakeReturns := fake.listKubernetesResourcesByTaskIDReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
@@ -751,13 +950,22 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
 	return len(fake.listKubernetesResourcesByTaskIDArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesResourcesByTaskIDCalls(stub func(string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
+	fake.ListKubernetesResourcesByTaskIDStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDArgsForCall(i int) string {
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	return fake.listKubernetesResourcesByTaskIDArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesResourcesByTaskIDArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	fake.listKubernetesResourcesByTaskIDReturns = struct {
 		result1 []kubernetes.Resource
@@ -766,6 +974,8 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	if fake.listKubernetesResourcesByTaskIDReturnsOnCall == nil {
 		fake.listKubernetesResourcesByTaskIDReturnsOnCall = make(map[int]struct {
@@ -775,59 +985,6 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, resu
 	}
 	fake.listKubernetesResourcesByTaskIDReturnsOnCall[i] = struct {
 		result1 []kubernetes.Resource
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(arg1 string, arg2 string, arg3 string) ([]string, error) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
-	ret, specificReturn := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)]
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall = append(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall, struct {
-		arg1 string
-		arg2 string
-		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
-	if fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub != nil {
-		return fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result2
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCallCount() int {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
-	return len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall(i int) (string, string, string) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
-	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg2, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg3
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(result1 []string, result2 error) {
-	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns = struct {
-		result1 []string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
-	if fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall == nil {
-		fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall = make(map[int]struct {
-			result1 []string
-			result2 error
-		})
-	}
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[i] = struct {
-		result1 []string
 		result2 error
 	}{result1, result2}
 }
@@ -846,7 +1003,8 @@ func (fake *FakeClient) ListReadGroupsByAccountName(arg1 string) ([]string, erro
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listReadGroupsByAccountNameReturns.result1, fake.listReadGroupsByAccountNameReturns.result2
+	fakeReturns := fake.listReadGroupsByAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
@@ -855,13 +1013,22 @@ func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
 	return len(fake.listReadGroupsByAccountNameArgsForCall)
 }
 
+func (fake *FakeClient) ListReadGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
+	fake.ListReadGroupsByAccountNameStub = stub
+}
+
 func (fake *FakeClient) ListReadGroupsByAccountNameArgsForCall(i int) string {
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
-	return fake.listReadGroupsByAccountNameArgsForCall[i].arg1
+	argsForCall := fake.listReadGroupsByAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, result2 error) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	fake.listReadGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -870,6 +1037,8 @@ func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, res
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	if fake.listReadGroupsByAccountNameReturnsOnCall == nil {
 		fake.listReadGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -897,7 +1066,8 @@ func (fake *FakeClient) ListWriteGroupsByAccountName(arg1 string) ([]string, err
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listWriteGroupsByAccountNameReturns.result1, fake.listWriteGroupsByAccountNameReturns.result2
+	fakeReturns := fake.listWriteGroupsByAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
@@ -906,13 +1076,22 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
 	return len(fake.listWriteGroupsByAccountNameArgsForCall)
 }
 
+func (fake *FakeClient) ListWriteGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
+	fake.ListWriteGroupsByAccountNameStub = stub
+}
+
 func (fake *FakeClient) ListWriteGroupsByAccountNameArgsForCall(i int) string {
 	fake.listWriteGroupsByAccountNameMutex.RLock()
 	defer fake.listWriteGroupsByAccountNameMutex.RUnlock()
-	return fake.listWriteGroupsByAccountNameArgsForCall[i].arg1
+	argsForCall := fake.listWriteGroupsByAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, result2 error) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	fake.listWriteGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -921,6 +1100,8 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, re
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	if fake.listWriteGroupsByAccountNameReturnsOnCall == nil {
 		fake.listWriteGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -937,10 +1118,6 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameReturnsOnCall(i int, result1
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.deleteKubernetesProviderMutex.RLock()
-	defer fake.deleteKubernetesProviderMutex.RUnlock()
-	fake.getKubernetesProviderMutex.RLock()
-	defer fake.getKubernetesProviderMutex.RUnlock()
 	fake.createKubernetesProviderMutex.RLock()
 	defer fake.createKubernetesProviderMutex.RUnlock()
 	fake.createKubernetesResourceMutex.RLock()
@@ -949,6 +1126,10 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.createReadPermissionMutex.RUnlock()
 	fake.createWritePermissionMutex.RLock()
 	defer fake.createWritePermissionMutex.RUnlock()
+	fake.deleteKubernetesProviderMutex.RLock()
+	defer fake.deleteKubernetesProviderMutex.RUnlock()
+	fake.getKubernetesProviderMutex.RLock()
+	defer fake.getKubernetesProviderMutex.RUnlock()
 	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
 	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
 	fake.listKubernetesClustersByApplicationMutex.RLock()
@@ -957,12 +1138,12 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listKubernetesProvidersMutex.RUnlock()
 	fake.listKubernetesProvidersAndPermissionsMutex.RLock()
 	defer fake.listKubernetesProvidersAndPermissionsMutex.RUnlock()
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
 	fake.listWriteGroupsByAccountNameMutex.RLock()


### PR DESCRIPTION
This change includes the following:

- Adding post filter middleware to "/applications" endpoint to filter the list of all the apps down to only include the apps the user has the proper permission to.
- Refactoring "/applications" endpoint to call the filter function before returning a response
- Add test to auth_test file to cover PostFilterAuthorizedApplications middleware function
- Adding unit tests to cover  FilterAuthorizedApps middleware function 